### PR TITLE
Personhendelse interface

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DodsfallHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DodsfallHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 import java.time.LocalDate
 
 @Component
-class DodsfallHandler(val pdlClient: PdlClient) : PersonhendelseHåndterer {
+class DodsfallHandler(val pdlClient: PdlClient) : PersonhendelseHandler {
 
     override val type = PersonhendelseType.DØDSFALL
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DodsfallHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DodsfallHandler.kt
@@ -1,41 +1,23 @@
 package no.nav.familie.ef.personhendelse.handler
 
-import no.nav.familie.ef.personhendelse.client.OppgaveClient
-import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.client.pdl.PdlClient
 import no.nav.familie.ef.personhendelse.datoutil.tilNorskDatoformat
 import no.nav.familie.ef.personhendelse.generated.enums.ForelderBarnRelasjonRolle
-import no.nav.familie.ef.personhendelse.personhendelsemapping.PersonhendelseRepository
 import no.nav.familie.ef.personhendelse.util.identerUtenAktørId
 import no.nav.person.pdl.leesah.Personhendelse
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
 @Component
-class DodsfallHandler(
-        val pdlClient: PdlClient,
-        sakClient: SakClient,
-        oppgaveClient: OppgaveClient,
-        personhendelseRepository: PersonhendelseRepository
-) : PersonhendelseHandler(sakClient, oppgaveClient, personhendelseRepository) {
+class DodsfallHandler(val pdlClient: PdlClient) : PersonhendelseHåndterer {
 
     override val type = PersonhendelseType.DØDSFALL
-
-    override fun handle(personhendelse: Personhendelse) {
-        identerTilSøk(personhendelse).forEach { personIdenter ->
-            val finnesBehandlingForPerson = sakClient.finnesBehandlingForPerson(personIdenter)
-
-            if (finnesBehandlingForPerson) {
-                handlePersonhendelse(personhendelse, personIdenter.first())
-            }
-        }
-    }
 
     override fun lagOppgaveBeskrivelse(personhendelse: Personhendelse): String {
         return "Dødsfall med dødsdato: ${personhendelse.doedsfall.doedsdato.tilNorskDatoformat()}"
     }
 
-    private fun identerTilSøk(personhendelse: Personhendelse): List<Set<String>> {
+    override fun personidenterPerPersonSomSkalKontrolleres(personhendelse: Personhendelse): List<Set<String>> {
         val personIdenter = personhendelse.identerUtenAktørId()
         val identerTilSøk = mutableListOf(personIdenter)
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DøfødtBarnHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DøfødtBarnHandler.kt
@@ -1,18 +1,11 @@
 package no.nav.familie.ef.personhendelse.handler
 
-import no.nav.familie.ef.personhendelse.client.OppgaveClient
-import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.datoutil.tilNorskDatoformat
-import no.nav.familie.ef.personhendelse.personhendelsemapping.PersonhendelseRepository
 import no.nav.person.pdl.leesah.Personhendelse
 import org.springframework.stereotype.Component
 
 @Component
-class DøfødtBarnHandler(
-        sakClient: SakClient,
-        oppgaveClient: OppgaveClient,
-        personhendelseRepository: PersonhendelseRepository
-) : PersonhendelseHandler(sakClient, oppgaveClient, personhendelseRepository) {
+class DøfødtBarnHandler: PersonhendelseHåndterer {
 
     override val type = PersonhendelseType.DØDFØDT_BARN
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DøfødtBarnHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/DøfødtBarnHandler.kt
@@ -5,7 +5,7 @@ import no.nav.person.pdl.leesah.Personhendelse
 import org.springframework.stereotype.Component
 
 @Component
-class DøfødtBarnHandler: PersonhendelseHåndterer {
+class DøfødtBarnHandler: PersonhendelseHandler {
 
     override val type = PersonhendelseType.DØDFØDT_BARN
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseHandler.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.personhendelse.handler
 
 import no.nav.person.pdl.leesah.Personhendelse
 
-interface PersonhendelseHåndterer {
+interface PersonhendelseHandler {
 
     val type: PersonhendelseType
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseHåndterer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseHåndterer.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.ef.personhendelse.handler
+
+import no.nav.person.pdl.leesah.Personhendelse
+
+interface PersonhendelseHåndterer {
+
+    val type: PersonhendelseType
+
+    fun skalOppretteOppgave(personhendelse: Personhendelse) = true
+
+    fun lagOppgaveBeskrivelse(personhendelse: Personhendelse): String
+
+    /**
+     * Returnerer en liste med personidenter for hver person som vi skal kontrollere
+     * Eks når vi får en sivilstandshendelse returneres [["a1", "a2"]]
+     * Mens når vi skal håndtere dødsfall returneres identer til personen og eventuellt forelder, [[f1], [f2], [b1]]
+     */
+    fun personidenterPerPersonSomSkalKontrolleres(personhendelse: Personhendelse): List<Set<String>> =
+            listOf(personhendelse.personidenter.toSet())
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class PersonhendelseHandler(
+class PersonhendelseService(
         personhendelseHandlers: List<PersonhendelseHåndterer>,
         private val sakClient: SakClient,
         private val oppgaveClient: OppgaveClient,

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 
 @Service
 class PersonhendelseService(
-        personhendelseHandlers: List<PersonhendelseHåndterer>,
+        personhendelseHandlers: List<PersonhendelseHandler>,
         private val sakClient: SakClient,
         private val oppgaveClient: OppgaveClient,
         private val personhendelseRepository: PersonhendelseRepository
@@ -25,7 +25,7 @@ class PersonhendelseService(
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
-    private val handlers: Map<String, PersonhendelseHåndterer> = personhendelseHandlers.associateBy { it.type.hendelsetype }
+    private val handlers: Map<String, PersonhendelseHandler> = personhendelseHandlers.associateBy { it.type.hendelsetype }
 
     init {
         logger.info("Legger til handlers: {}", personhendelseHandlers)
@@ -45,7 +45,7 @@ class PersonhendelseService(
         }
     }
 
-    private fun handle(handler: PersonhendelseHåndterer, personhendelse: Personhendelse, personidenter: Set<String>) {
+    private fun handle(handler: PersonhendelseHandler, personhendelse: Personhendelse, personidenter: Set<String>) {
         val finnesBehandlingForPerson = sakClient.finnesBehandlingForPerson(personidenter)
 
         if (finnesBehandlingForPerson) {
@@ -53,7 +53,7 @@ class PersonhendelseService(
         }
     }
 
-    private fun handlePersonhendelse(handler: PersonhendelseHåndterer, personhendelse: Personhendelse, personIdent: String) {
+    private fun handlePersonhendelse(handler: PersonhendelseHandler, personhendelse: Personhendelse, personIdent: String) {
         if (personhendelse.skalOpphøreEllerKorrigeres()) {
             opphørEllerKorrigerOppgave(personhendelse)
             return
@@ -80,7 +80,7 @@ class PersonhendelseService(
         secureLogger.info("$logMessage personIdent=${personIdent}")
     }
 
-    private fun opprettOppgave(handler: PersonhendelseHåndterer, personhendelse: Personhendelse, personIdent: String) {
+    private fun opprettOppgave(handler: PersonhendelseHandler, personhendelse: Personhendelse, personIdent: String) {
         val oppgaveBeskrivelse = handler.lagOppgaveBeskrivelse(personhendelse)
         val opprettOppgaveRequest = defaultOpprettOppgaveRequest(personIdent, "Personhendelse: $oppgaveBeskrivelse")
         val oppgaveId = oppgaveClient.opprettOppgave(opprettOppgaveRequest)

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/SivilstandHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/SivilstandHandler.kt
@@ -1,19 +1,16 @@
 package no.nav.familie.ef.personhendelse.handler
 
-import no.nav.familie.ef.personhendelse.client.OppgaveClient
-import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.datoutil.tilNorskDatoformat
-import no.nav.familie.ef.personhendelse.personhendelsemapping.PersonhendelseRepository
 import no.nav.person.pdl.leesah.Endringstype
 import no.nav.person.pdl.leesah.Personhendelse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
-class SivilstandHandler(
-        sakClient: SakClient,
-        oppgaveClient: OppgaveClient,
-        personhendelseRepository: PersonhendelseRepository
-) : PersonhendelseHandler(sakClient, oppgaveClient, personhendelseRepository) {
+class SivilstandHandler: PersonhendelseHåndterer {
+
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     override val type = PersonhendelseType.SIVILSTAND
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/SivilstandHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/SivilstandHandler.kt
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
-class SivilstandHandler: PersonhendelseHåndterer {
+class SivilstandHandler: PersonhendelseHandler {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/UtflyttingHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/UtflyttingHandler.kt
@@ -1,18 +1,11 @@
 package no.nav.familie.ef.personhendelse.handler
 
-import no.nav.familie.ef.personhendelse.client.OppgaveClient
-import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.datoutil.tilNorskDatoformat
-import no.nav.familie.ef.personhendelse.personhendelsemapping.PersonhendelseRepository
 import no.nav.person.pdl.leesah.Personhendelse
 import org.springframework.stereotype.Component
 
 @Component
-class UtflyttingHandler(
-    sakClient: SakClient,
-    oppgaveClient: OppgaveClient,
-    personhendelseRepository: PersonhendelseRepository
-) : PersonhendelseHandler(sakClient, oppgaveClient, personhendelseRepository) {
+class UtflyttingHandler : PersonhendelseHåndterer {
 
     override val type = PersonhendelseType.UTFLYTTING_FRA_NORGE
 
@@ -22,9 +15,9 @@ class UtflyttingHandler(
 }
 
 private fun Personhendelse.utflyttingsBeskrivelse() =
-    "Utflyttingshendelse til ${this.utflyttingFraNorge.tilflyttingsstedIUtlandet}, " +
-            "{${this.utflyttingFraNorge.tilflyttingsland}. " +
-            "Utflyttingsdato: ${this.utflyttingFraNorge.utflyttingsdato.tilNorskDatoformat()}"
+        "Utflyttingshendelse til ${this.utflyttingFraNorge.tilflyttingsstedIUtlandet}, " +
+        "{${this.utflyttingFraNorge.tilflyttingsland}. " +
+        "Utflyttingsdato: ${this.utflyttingFraNorge.utflyttingsdato.tilNorskDatoformat()}"
 
 
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/UtflyttingHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/UtflyttingHandler.kt
@@ -5,7 +5,7 @@ import no.nav.person.pdl.leesah.Personhendelse
 import org.springframework.stereotype.Component
 
 @Component
-class UtflyttingHandler : PersonhendelseHåndterer {
+class UtflyttingHandler : PersonhendelseHandler {
 
     override val type = PersonhendelseType.UTFLYTTING_FRA_NORGE
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.personhendelse.kafka
 
-import no.nav.familie.ef.personhendelse.handler.PersonhendelseHandler
+import no.nav.familie.ef.personhendelse.handler.PersonhendelseService
 import no.nav.familie.ef.personhendelse.util.identerUtenAktørId
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.mdc.MDCConstants
@@ -22,7 +22,7 @@ import java.util.UUID
 class PersonhendelseListener(
         @Value("\${SPRING_PROFILES_ACTIVE}")
         private val env: String,
-        private val personhendelseHandler: PersonhendelseHandler
+        private val personhendelseService: PersonhendelseService
 ) : ConsumerSeekAware {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -37,7 +37,7 @@ class PersonhendelseListener(
             val personidenter = personhendelse.identerUtenAktørId()
             //Finnes hendelser uten personIdent i dev som følge av opprydding i testdata
             if (!personidenter.firstOrNull().isNullOrBlank()) {
-                personhendelseHandler.håndterPersonhendelse(personhendelse)
+                personhendelseService.håndterPersonhendelse(personhendelse)
             } else {
                 if (env != "dev") throw RuntimeException("Hendelse uten personIdent mottatt for hendelseId: ${personhendelse.hendelseId}")
             }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.personhendelse.kafka
 
 import no.nav.familie.ef.personhendelse.handler.PersonhendelseHandler
 import no.nav.familie.ef.personhendelse.util.identerUtenAktørId
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.person.pdl.leesah.Personhendelse
 import org.slf4j.LoggerFactory
@@ -19,22 +20,13 @@ import java.util.UUID
  */
 @Component
 class PersonhendelseListener(
-        personhendelseHandlers: List<PersonhendelseHandler>,
         @Value("\${SPRING_PROFILES_ACTIVE}")
-        private val env: String
+        private val env: String,
+        private val personhendelseHandler: PersonhendelseHandler
 ) : ConsumerSeekAware {
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val securelogger = LoggerFactory.getLogger("secureLogger")
-
-    private val handlers: Map<String, PersonhendelseHandler> = personhendelseHandlers.associateBy { it.type.hendelsetype }
-
-    init {
-        logger.info("Legger til handlers: {}", personhendelseHandlers)
-        if (personhendelseHandlers.isEmpty()) {
-            error("Finner ikke handlers for personhendelse")
-        }
-    }
 
     @KafkaListener(id = "familie-ef-personhendelse",
                    topics = ["aapen-person-pdl-leesah-v1"],
@@ -45,13 +37,15 @@ class PersonhendelseListener(
             val personidenter = personhendelse.identerUtenAktørId()
             //Finnes hendelser uten personIdent i dev som følge av opprydding i testdata
             if (!personidenter.firstOrNull().isNullOrBlank()) {
-                handlers[personhendelse.opplysningstype]?.handle(personhendelse)
+                personhendelseHandler.håndterPersonhendelse(personhendelse)
             } else {
                 if (env != "dev") throw RuntimeException("Hendelse uten personIdent mottatt for hendelseId: ${personhendelse.hendelseId}")
             }
         } catch (e: Exception) {
             logger.error("Feil ved håndtering av personhendelse med hendelseId: ${personhendelse.hendelseId}")
-            securelogger.error("Feil ved håndtering av personhendelse med hendelseId ${personhendelse.hendelseId}: ${e.message}")
+            securelogger.error("Feil ved håndtering av personhendelse med hendelseId ${personhendelse.hendelseId}: ${e.message}" +
+                               " hendelse={}",
+                               objectMapper.writeValueAsString(personhendelse))
             throw e
         } finally {
             MDC.remove(MDCConstants.MDC_CALL_ID)

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/LoadHandlersTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/LoadHandlersTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.personhendelse.handler
 
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 


### PR DESCRIPTION
Endrer til å bruke interface for personhendelse i stedet for abstract då handlers ikke trenger noe forhold til sakclient, oppgave etc. Men att dette legges i en personhendelseService

Notere att det ser ut som veldig mye kode er endret i PersonhendelseHandler, det er fordi den har endringer og har endret navn. Dette er gjort i forskjellige commits sånn att diffen blir litt enklere å skjønne hvis man ser per commit