### PR TITLE
Oppretter oppgaver ved vedtak- og inntektsendringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/ArbeidsfordelingClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/ArbeidsfordelingClient.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.ef.personhendelse.client
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.PersonIdent
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+@Component
+class ArbeidsfordelingClient(
+    @Qualifier("azure") restOperations: RestOperations,
+    @Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: String
+) : AbstractRestClient(restOperations, "familie.integrasjoner") {
+
+    private val hentBehandlendeEnhetMedRelasjonerUrl = "$integrasjonUri/api/arbeidsfordeling/enhet/ENF/med-relasjoner"
+
+    fun hentArbeidsfordelingEnhetId(ident: String): String? {
+        val response = postForEntity<Ressurs<List<Arbeidsfordelingsenhet>>>(URI.create(hentBehandlendeEnhetMedRelasjonerUrl), PersonIdent(ident))
+        return response.data?.firstOrNull()?.enhetId
+    }
+}
+
+data class Arbeidsfordelingsenhet(val enhetId: String, val enhetNavn: String)

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
@@ -13,7 +13,7 @@ import no.nav.person.pdl.leesah.Personhendelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
 class PersonhendelseService(

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
@@ -13,14 +13,14 @@ import no.nav.person.pdl.leesah.Personhendelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.UUID
+import java.util.*
 
 @Service
 class PersonhendelseService(
-        personhendelseHandlers: List<PersonhendelseHandler>,
-        private val sakClient: SakClient,
-        private val oppgaveClient: OppgaveClient,
-        private val personhendelseRepository: PersonhendelseRepository
+    personhendelseHandlers: List<PersonhendelseHandler>,
+    private val sakClient: SakClient,
+    private val oppgaveClient: OppgaveClient,
+    private val personhendelseRepository: PersonhendelseRepository
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -48,8 +48,10 @@ class PersonhendelseService(
 
     private fun handle(handler: PersonhendelseHandler, personhendelse: Personhendelse, personidenter: Set<String>) {
         val finnesBehandlingForPerson = sakClient.harStønadSiste12MånederForPersonidenter(personidenter)
-        logger.info("Personhendelse av opplysningstype : ${personhendelse.opplysningstype} av type : ${personhendelse.endringstype.name}." +
-                    " Behandling finnes : $finnesBehandlingForPerson . ")
+        logger.info(
+            "Personhendelse av opplysningstype : ${personhendelse.opplysningstype} av type : ${personhendelse.endringstype.name}." +
+                " Behandling finnes : $finnesBehandlingForPerson . "
+        )
         if (finnesBehandlingForPerson) {
             handlePersonhendelse(handler, personhendelse, personidenter.first())
         }
@@ -70,14 +72,14 @@ class PersonhendelseService(
     }
 
     private fun logHendelse(
-            personhendelse: Personhendelse,
-            skalOppretteOppgave: Boolean,
-            personIdent: String?
+        personhendelse: Personhendelse,
+        skalOppretteOppgave: Boolean,
+        personIdent: String?
     ) {
         val logMessage = "Finnes sak for opplysningstype=${personhendelse.opplysningstype}" +
-                         " hendelseId=${personhendelse.hendelseId}" +
-                         " endringstype=${personhendelse.endringstype}" +
-                         " skalOppretteOppgave=$skalOppretteOppgave"
+            " hendelseId=${personhendelse.hendelseId}" +
+            " endringstype=${personhendelse.endringstype}" +
+            " skalOppretteOppgave=$skalOppretteOppgave"
         logger.info(logMessage)
         secureLogger.info("$logMessage personIdent=$personIdent")
     }
@@ -122,22 +124,22 @@ class PersonhendelseService(
         lagreHendelse(personhendelse, oppgave.id!!)
     }
 
-    private fun leggOppgaveIMappe(oppgaveId: Long) {
+    fun leggOppgaveIMappe(oppgaveId: Long) {
         val oppgave = oppgaveClient.finnOppgaveMedId(oppgaveId)
         if (oppgave.tildeltEnhetsnr == EF_ENHETNUMMER) { // Skjermede personer skal ikke puttes i mappe
             val finnMappeRequest = FinnMappeRequest(
-                    listOf(),
-                    oppgave.tildeltEnhetsnr!!,
-                    null,
-                    1000
+                listOf(),
+                oppgave.tildeltEnhetsnr!!,
+                null,
+                1000
             )
             val mapperResponse = oppgaveClient.finnMapper(finnMappeRequest)
             val mappe = mapperResponse.mapper.find {
                 it.navn.contains("EF Sak", true) &&
-                it.navn.contains("Hendelser") &&
-                it.navn.contains("62")
+                    it.navn.contains("Hendelser") &&
+                    it.navn.contains("62")
             }
-                        ?: error("Fant ikke mappe for uplassert oppgave (EF Sak og 01)")
+                ?: error("Fant ikke mappe for uplassert oppgave (EF Sak og 01)")
             oppgaveClient.oppdaterOppgave(oppgave.copy(mappeId = mappe.id.toLong()))
         }
     }
@@ -153,9 +155,9 @@ class PersonhendelseService(
 
     private fun lagreHendelse(personhendelse: Personhendelse, oppgaveId: Long) {
         personhendelseRepository.lagrePersonhendelse(
-                UUID.fromString(personhendelse.hendelseId),
-                oppgaveId,
-                personhendelse.endringstype
+            UUID.fromString(personhendelse.hendelseId),
+            oppgaveId,
+            personhendelse.endringstype
         )
     }
 
@@ -165,19 +167,19 @@ class PersonhendelseService(
 
     private fun opprettOppgaveMedBeskrivelse(personhendelse: Personhendelse, beskrivelse: String): Long {
         return oppgaveClient.opprettOppgave(
-                defaultOpprettOppgaveRequest(
-                        personhendelse.personidenter.first(),
-                        beskrivelse
-                )
+            defaultOpprettOppgaveRequest(
+                personhendelse.personidenter.first(),
+                beskrivelse
+            )
         )
     }
 }
 
 private fun Personhendelse.ferdigstiltBeskrivelse() =
-        "En hendelse av typen ${this.endringstype.name} har oppstått for en ferdigstilt oppgave"
+    "En hendelse av typen ${this.endringstype.name} har oppstått for en ferdigstilt oppgave"
 
 private fun Personhendelse.finnesIngenHendelseBeskrivelse() =
-        "Det har oppstått en personhendelse som det ikke finnes noen tidligere hendelse eller oppgave for. " +
+    "Det har oppstått en personhendelse som det ikke finnes noen tidligere hendelse eller oppgave for. " +
         "Personhendelse id : ${this.hendelseId}, ${this.endringstype.name}"
 
 private fun Oppgave.erÅpen() = !listOf(StatusEnum.FERDIGSTILT, StatusEnum.FEILREGISTRERT).contains(this.status)
@@ -187,4 +189,4 @@ private fun Oppgave.opphørtEllerAnnullertBeskrivelse() = "\n\nDenne oppgaven ha
 private fun Oppgave.korrigertBeskrivelse() = "\n\nDenne oppgaven har blitt korrigert."
 
 private fun Personhendelse.skalOpphøreEllerKorrigeres() =
-        listOf(Endringstype.ANNULLERT, Endringstype.KORRIGERT, Endringstype.OPPHOERT).contains(this.endringstype)
+    listOf(Endringstype.ANNULLERT, Endringstype.KORRIGERT, Endringstype.OPPHOERT).contains(this.endringstype)

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -31,27 +31,9 @@ class InntektsendringerService(
         val nyesteVersjon = nyesteRegistrerteInntekt?.maxOf { it.versjon }
         val inntektListe = nyesteRegistrerteInntekt?.firstOrNull { it.versjon == nyesteVersjon }?.arbeidsInntektInformasjon?.inntektListe
 
-        val samletInntekt = inntektListe?.filter { it.inntektType != InntektType.YTELSE_FRA_OFFENTLIGE }?.sumOf { it.beløp } ?: 0
+        val samletInntekt = inntektListe?.filter { !ignorerteYtelserIBeregningAvInntekt.contains(it.beskrivelse) }?.sumOf { it.beløp } ?: 0
         secureLogger.info("Samlet inntekt: $samletInntekt - månedlig forventet inntekt: $månedligForventetInntekt  (årlig: ${identMedForventetInntekt.value}) for person ${identMedForventetInntekt.key}")
         return samletInntekt >= (månedligForventetInntekt * 1.1) && samletInntekt > 0 // Må sjekke om samletInntekt er større enn 0 for å ikke få true dersom alle variabler er 0 (antakelig kun i test)
-    }
-
-    // Denne kan være vanskelig å bruke, da det kan være mye etterbetalinger som gir falsk positiv
-    private fun harMottattMerIOffentligeYtelser(nestNyesteRegistrerteInntekt: List<InntektVersjon>?, nyesteRegistrerteInntekt: List<InntektVersjon>?): Boolean {
-        val sumOffentligeYtelserForNyeste = sumOffentligeYtelser(nyesteRegistrerteInntekt)
-        val sumOffentligeYtelserForNestNyeste = sumOffentligeYtelser(nestNyesteRegistrerteInntekt)
-
-        return (sumOffentligeYtelserForNyeste > sumOffentligeYtelserForNestNyeste)
-    }
-
-    private fun sumOffentligeYtelser(nyesteRegistrerteInntekt: List<InntektVersjon>?): Int {
-        val nyesteVersjon = nyesteRegistrerteInntekt?.maxOf { it.versjon }
-
-        val inntektListe = nyesteRegistrerteInntekt?.firstOrNull { it.versjon == nyesteVersjon }?.arbeidsInntektInformasjon?.inntektListe
-        val beløpYtelseFraOffentligList = inntektListe?.filter {
-            it.inntektType == InntektType.YTELSE_FRA_OFFENTLIGE && !ignorerteYtelserIBeregningAvInntekt.contains(it.beskrivelse)
-        }?.map { it.beløp } ?: listOf() // Sjekker kun mot faste månedlige utbetalinger (ikke dagpenger / AAP fordi de ofte er variable)
-        return beløpYtelseFraOffentligList.sumOf { it }
     }
 
     // Ignorterte ytelser: AAP og Dagpenger er ignorert fordi de er variable. Alle uføre går under annet regelverk (samordning) og skal derfor ignoreres.

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -12,27 +12,27 @@ class InntektsendringerService(
     val sakClient: SakClient
 ) {
 
-    fun harEndretInntekt(inntektshistorikkResponse: InntektshistorikkResponse, identMedForventetInntekt: Map.Entry<String, Int?>): Boolean {
+    fun harEndretInntekt(inntektshistorikkResponse: InntektshistorikkResponse, ident: String, forventetInntekt: Int?): Boolean {
         // hent alle registrerte vedtak som var på personen sist beregning
         val nyesteRegistrerteInntekt = inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(1).toString())
 
-        return har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt, identMedForventetInntekt)
+        return har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt, ident, forventetInntekt)
     }
 
-    private fun har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt: List<InntektVersjon>?, identMedForventetInntekt: Map.Entry<String, Int?>): Boolean {
+    private fun har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt: List<InntektVersjon>?, ident: String, forventetInntekt: Int?): Boolean {
 
-        if (identMedForventetInntekt.value == null) {
-            secureLogger.warn("Ingen gjeldende inntekt funnet på person ${identMedForventetInntekt.key} har personen løpende stønad?")
+        if (forventetInntekt == null) {
+            secureLogger.warn("Ingen gjeldende inntekt funnet på person $ident har personen løpende stønad?")
             return false
         }
-        if (identMedForventetInntekt.value!! > 585000) return false // Ignorer alle med over 585000 i årsinntekt, da de har 0 i utbetaling.
-        val månedligForventetInntekt = (identMedForventetInntekt.value!! / 12)
+        if (forventetInntekt > 585000) return false // Ignorer alle med over 585000 i årsinntekt, da de har 0 i utbetaling.
+        val månedligForventetInntekt = (forventetInntekt / 12)
 
         val nyesteVersjon = nyesteRegistrerteInntekt?.maxOf { it.versjon }
         val inntektListe = nyesteRegistrerteInntekt?.firstOrNull { it.versjon == nyesteVersjon }?.arbeidsInntektInformasjon?.inntektListe
 
         val samletInntekt = inntektListe?.filter { !ignorerteYtelserIBeregningAvInntekt.contains(it.beskrivelse) }?.sumOf { it.beløp } ?: 0
-        secureLogger.info("Samlet inntekt: $samletInntekt - månedlig forventet inntekt: $månedligForventetInntekt  (årlig: ${identMedForventetInntekt.value}) for person ${identMedForventetInntekt.key}")
+        secureLogger.info("Samlet inntekt: $samletInntekt - månedlig forventet inntekt: $månedligForventetInntekt  (årlig: $forventetInntekt) for person $ident")
         return samletInntekt >= (månedligForventetInntekt * 1.1) && samletInntekt > 0 // Må sjekke om samletInntekt er større enn 0 for å ikke få true dersom alle variabler er 0 (antakelig kun i test)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -21,15 +21,15 @@ class InntektsendringerService(
 
     private fun har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt: List<InntektVersjon>?, ident: String, forventetInntekt: Int?): Boolean {
 
-        if (forventetInntekt == null) {
+        if (forventetInntekt == null || nyesteRegistrerteInntekt?.maxOfOrNull { it.versjon } == null) {
             secureLogger.warn("Ingen gjeldende inntekt funnet på person $ident har personen løpende stønad?")
             return false
         }
         if (forventetInntekt > 585000) return false // Ignorer alle med over 585000 i årsinntekt, da de har 0 i utbetaling.
         val månedligForventetInntekt = (forventetInntekt / 12)
 
-        val nyesteVersjon = nyesteRegistrerteInntekt?.maxOf { it.versjon }
-        val inntektListe = nyesteRegistrerteInntekt?.firstOrNull { it.versjon == nyesteVersjon }?.arbeidsInntektInformasjon?.inntektListe
+        val nyesteVersjon = nyesteRegistrerteInntekt.maxOf { it.versjon }
+        val inntektListe = nyesteRegistrerteInntekt.firstOrNull { it.versjon == nyesteVersjon }?.arbeidsInntektInformasjon?.inntektListe
 
         val samletInntekt = inntektListe?.filter { !ignorerteYtelserIBeregningAvInntekt.contains(it.beskrivelse) }?.sumOf { it.beløp } ?: 0
         secureLogger.info("Samlet inntekt: $samletInntekt - månedlig forventet inntekt: $månedligForventetInntekt  (årlig: $forventetInntekt) for person $ident")

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -2,12 +2,23 @@ package no.nav.familie.ef.personhendelse.inntekt
 
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.client.fristFerdigstillelse
+import no.nav.familie.ef.personhendelse.handler.PersonhendelseService
 import no.nav.familie.ef.personhendelse.inntekt.vedtak.EfVedtakRepository
+import no.nav.familie.ef.personhendelse.inntekt.vedtak.VedtakhendelseInntektberegning
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.time.YearMonth
+import java.util.*
 
 @Service
 class VedtakendringerService(
@@ -15,7 +26,8 @@ class VedtakendringerService(
     val inntektClient: InntektClient,
     val oppgaveClient: OppgaveClient,
     val sakClient: SakClient,
-    val inntektsendringerService: InntektsendringerService
+    val inntektsendringerService: InntektsendringerService,
+    val personhendelseService: PersonhendelseService
 ) {
 
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -23,46 +35,23 @@ class VedtakendringerService(
 
     @Async
     fun beregnNyeVedtakOgLagOppgave() {
-        // val personerMedVedtakList = efVedtakRepository.hentAllePersonerMedVedtak() // for testing
+        val personerMedVedtakList = efVedtakRepository.hentPersonerMedVedtakIkkeBehandlet()
 
         val identToForventetInntektMap = sakClient.hentAlleAktiveIdenterOgForventetInntekt()
         logger.info("Antall personer med aktive vedtak: ${identToForventetInntektMap.keys.size}")
 
-        // Kommer til å bytte til batch-prosessering for forbedring av ytelse
-        for (identMedForventetInntekt in identToForventetInntektMap.entries) {
+        personerMedVedtakList.forEach {
+            val response = hentInntektshistorikk(it.personIdent)
+            if (response != null) {
+                val harNyeVedtak = harNyeVedtak(response)
+                val harEndretInntekt = inntektsendringerService.harEndretInntekt(response, AbstractMap.SimpleEntry(it.personIdent, identToForventetInntektMap[it.personIdent]))
 
-            val response = hentInntektshistorikk(identMedForventetInntekt)
-
-            if (response != null && harNyeVedtak(response)) {
-                secureLogger.info("Person ${identMedForventetInntekt.key} kan ha nye vedtak. Oppretter oppgave.")
-                /*
-                val oppgaveId = oppgaveClient.opprettOppgave(
-                    defaultOpprettOppgaveRequest(
-                        ensligForsørgerVedtakhendelse.personIdent,
-                        "Sjekk om bruker har fått nytt vedtak"
-                    )
-                )
-                secureLogger.info("Oppgave opprettet med id: $oppgaveId")
-                 */
+                if (harNyeVedtak || harEndretInntekt) {
+                    opprettOppgave(harNyeVedtak, harEndretInntekt, it)
+                }
+                efVedtakRepository.oppdaterAarMaanedProsessert(it.personIdent)
             }
-            if (response != null && inntektsendringerService.harEndretInntekt(response, identMedForventetInntekt)) {
-                secureLogger.info("Person ${identMedForventetInntekt.key} kan ha endret inntekt. Oppretter oppgave.")
-            }
-            // efVedtakRepository.oppdaterAarMaanedProsessert(identMedForventetInntekt.key)
         }
-    }
-
-    private fun hentInntektshistorikk(identMedForventetInntekt: Map.Entry<String, Int?>): InntektshistorikkResponse? {
-        try {
-            return inntektClient.hentInntektshistorikk(
-                identMedForventetInntekt.key,
-                YearMonth.now().minusYears(1),
-                null
-            )
-        } catch (e: Exception) {
-            secureLogger.warn("Feil ved kall mot inntektskomponenten ved kall mot person ${identMedForventetInntekt.key}. Message: ${e.message} Cause: ${e.cause}")
-        }
-        return null
     }
 
     fun harNyeVedtak(inntektshistorikkResponse: InntektshistorikkResponse): Boolean {
@@ -95,5 +84,56 @@ class VedtakendringerService(
             it.inntektType == InntektType.YTELSE_FRA_OFFENTLIGE &&
                 it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere"
         }?.groupBy { it.beskrivelse }?.size ?: 0
+    }
+
+    private fun hentInntektshistorikk(fnr: String): InntektshistorikkResponse? {
+        try {
+            return inntektClient.hentInntektshistorikk(
+                fnr,
+                YearMonth.now().minusYears(1),
+                null
+            )
+        } catch (e: Exception) {
+            secureLogger.warn("Feil ved kall mot inntektskomponenten ved kall mot person $fnr. Message: ${e.message} Cause: ${e.cause}")
+        }
+        return null
+    }
+
+    private fun opprettOppgave(harNyeVedtak: Boolean, harEndretInntekt: Boolean, vedtakhendelseInntektberegning: VedtakhendelseInntektberegning) {
+        val oppgavetekst = lagOppgavetekst(harNyeVedtak, harEndretInntekt)
+        secureLogger.info("${vedtakhendelseInntektberegning.personIdent} - $oppgavetekst")
+        val oppgaveId = oppgaveClient.opprettOppgave(
+            OpprettOppgaveRequest(
+                ident = OppgaveIdentV2(ident = vedtakhendelseInntektberegning.personIdent, gruppe = IdentGruppe.FOLKEREGISTERIDENT),
+                saksId = null,
+                tema = Tema.ENF,
+                oppgavetype = Oppgavetype.VurderKonsekvensForYtelse,
+                fristFerdigstillelse = fristFerdigstillelse(),
+                beskrivelse = oppgavetekst,
+                enhetsnummer = null,
+                behandlingstema = vedtakhendelseInntektberegning.stønadType.tilBehandlingstemaValue(),
+                tilordnetRessurs = null,
+                behandlesAvApplikasjon = "familie-ef-sak"
+            )
+        )
+        personhendelseService.leggOppgaveIMappe(oppgaveId)
+    }
+
+    private fun lagOppgavetekst(harNyeVedtak: Boolean, harEndretInntekt: Boolean): String {
+        if (harNyeVedtak && harEndretInntekt) {
+            return "Person kan ha nye vedtak og endret inntekt."
+        } else if (harNyeVedtak) {
+            return "Person kan ha nye vedtak."
+        } else {
+            return "Person kan ha endret inntekt"
+        }
+    }
+}
+
+fun StønadType.tilBehandlingstemaValue(): String {
+    return when (this) {
+        StønadType.OVERGANGSSTØNAD -> Behandlingstema.Overgangsstønad.value
+        StønadType.BARNETILSYN -> Behandlingstema.Barnetilsyn.value
+        StønadType.SKOLEPENGER -> Behandlingstema.Skolepenger.value
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -118,7 +118,7 @@ class VedtakendringerService(
                 behandlesAvApplikasjon = "familie-ef-sak"
             )
         )
-
+        secureLogger.info("Opprettet oppgave for person ${vedtakhendelseInntektberegning.personIdent} med id: $oppgaveId")
         try {
             personhendelseService.leggOppgaveIMappe(oppgaveId)
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -11,7 +11,7 @@ import java.time.YearMonth
 @Repository
 class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTemplate) {
 
-    fun lagreEfVedtakshendelse(vedtakshendelse: EnsligForsørgerVedtakhendelse) {
+    fun lagreEfVedtakshendelse(vedtakshendelse: EnsligForsørgerVedtakhendelse, aarMaanedProsessert: YearMonth = YearMonth.now()) {
         val sql = "INSERT INTO efvedtakhendelse VALUES(:behandlingId, :personIdent, :stønadType, :aar_maaned_prosessert, :versjon)" +
             " ON CONFLICT DO NOTHING"
         val params = MapSqlParameterSource(
@@ -19,7 +19,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
                 "behandlingId" to vedtakshendelse.behandlingId,
                 "personIdent" to vedtakshendelse.personIdent,
                 "stønadType" to vedtakshendelse.stønadType.toString(),
-                "aar_maaned_prosessert" to YearMonth.now().toString(),
+                "aar_maaned_prosessert" to aarMaanedProsessert.toString(),
                 "versjon" to 1
             )
         )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -34,8 +34,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
 
     fun hentPersonerMedVedtakIkkeBehandlet(): List<VedtakhendelseInntektberegning> {
         val sql = "SELECT * FROM efvedtakhendelse WHERE aar_maaned_prosessert != '${YearMonth.now()}'"
-        val mapSqlParameterSource = MapSqlParameterSource("stonadstype", StønadType.OVERGANGSSTØNAD.toString())
-        return namedParameterJdbcTemplate.query(sql, mapSqlParameterSource, vedtakhendelseInntektberegningMapper)
+        return namedParameterJdbcTemplate.query(sql, vedtakhendelseInntektberegningMapper)
     }
 
     private val vedtakhendelseInntektberegningMapper = { rs: ResultSet, _: Int ->

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/IntegrasjonstestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/IntegrasjonstestConfig.kt
@@ -1,8 +1,24 @@
 package no.nav.familie.ef.personhendelse
 
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 
 @Profile("integrasjonstest")
 @Configuration
-class IntegrasjonstestConfig
+class IntegrasjonstestConfig {
+
+    @Bean
+    @Primary
+    fun oAuth2AccessTokenServiceMock(): OAuth2AccessTokenService {
+        val tokenMockService = mockk<OAuth2AccessTokenService>()
+        every { tokenMockService.getAccessToken(any()) }
+            .returns(OAuth2AccessTokenResponse("Mock-token-response", 60, 60, null))
+        return tokenMockService
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/config/EfSakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/config/EfSakClientMock.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ef.personhendelse.config
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.personhendelse.client.SakClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@Configuration
+class EfSakClientMock {
+
+    @Bean
+    @Profile("mock-efsak")
+    @Primary
+    fun oppgaveMockRestClient(): SakClient {
+        val klient: SakClient = mockk(relaxed = false)
+
+        every {
+            klient.harAktivtVedtak(any())
+        } returns true
+
+        every {
+            klient.hentAlleAktiveIdenterOgForventetInntekt()
+        } returns mapOf("1" to 100000, "2" to 150000)
+
+        return klient
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -54,6 +54,24 @@ class InntektsendringerServiceTest {
     }
 
     @Test
+    fun `Utbetaling av offentlig ytelse og lønnsinntekt utgjør til sammen mer enn 10 prosent av forventet inntekt`() {
+        val json: String = readResource("inntekt/InntekthistorikkLoennsinntektOgOffentligYtelseEksempel.json")
+        val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
+
+        val inntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+
+        val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
+            linkedMapOf(
+                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("5", listOf(InntektVersjon(inntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1)))))
+            )
+        )
+
+        val forventetInntektTiProsentLavere = AbstractMap.SimpleEntry("2", (forventetLønnsinntekt * 0.9).toInt())
+
+        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, forventetInntektTiProsentLavere)).isFalse
+    }
+
+    @Test
     fun `Har for høy forventet inntekt, skal returnere false`() {
         val json: String = readResource("inntekt/InntekthistorikkLoennsinntektEksempel.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
 import java.time.YearMonth
-import java.util.*
 
 class InntektsendringerServiceTest {
 
@@ -44,13 +43,12 @@ class InntektsendringerServiceTest {
             )
         )
 
-        val sammeInntekt = AbstractMap.SimpleEntry("1", forventetLønnsinntekt)
-        val forventetInntektTiProsentLavere = AbstractMap.SimpleEntry("2", (forventetLønnsinntekt * 0.9).toInt())
-        val forventetInntektNiProsentLavere = AbstractMap.SimpleEntry("3", (forventetLønnsinntekt * 0.91).toInt())
+        val forventetInntektTiProsentLavere = (forventetLønnsinntekt * 0.9).toInt()
+        val forventetInntektNiProsentLavere = (forventetLønnsinntekt * 0.91).toInt()
 
-        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, sammeInntekt)).isFalse
-        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, forventetInntektTiProsentLavere)).isTrue
-        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, forventetInntektNiProsentLavere)).isFalse
+        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, "1", forventetLønnsinntekt)).isFalse
+        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, "2", forventetInntektTiProsentLavere)).isTrue
+        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, "3", forventetInntektNiProsentLavere)).isFalse
     }
 
     @Test
@@ -66,9 +64,9 @@ class InntektsendringerServiceTest {
             )
         )
 
-        val forventetInntektTiProsentLavere = AbstractMap.SimpleEntry("2", (forventetLønnsinntekt * 0.9).toInt())
+        val forventetInntektTiProsentLavere = (forventetLønnsinntekt * 0.9).toInt()
 
-        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, forventetInntektTiProsentLavere)).isFalse
+        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, "2", forventetInntektTiProsentLavere)).isFalse
     }
 
     @Test
@@ -86,8 +84,8 @@ class InntektsendringerServiceTest {
             )
         )
 
-        val høyInntekt = AbstractMap.SimpleEntry("1", 585001)
-        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, høyInntekt)).isFalse
+        val forHøyInntekt = 585001
+        Assertions.assertThat(inntektsendringer.harEndretInntekt(oppdatertDatoInntektshistorikkResponse, "1", forHøyInntekt)).isFalse
     }
 
     fun readResource(name: String): String {

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.personhendelse.inntekt
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.mockk
+import no.nav.familie.ef.personhendelse.client.ArbeidsfordelingClient
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.handler.PersonhendelseService
@@ -20,9 +21,10 @@ class VedtakendringerServiceTest {
     private val inntektClient = mockk<InntektClient>()
     private val oppgaveClient = mockk<OppgaveClient>()
     private val sakClient = mockk<SakClient>()
+    private val arbeidsfordelingClient = mockk<ArbeidsfordelingClient>()
     private val inntektsendringerService = mockk<InntektsendringerService>()
     private val personhendelseService = mockk<PersonhendelseService>()
-    private val vedtakendringer = VedtakendringerService(efVedtakRepository, inntektClient, oppgaveClient, sakClient, inntektsendringerService, personhendelseService)
+    private val vedtakendringer = VedtakendringerService(efVedtakRepository, inntektClient, oppgaveClient, sakClient, arbeidsfordelingClient, inntektsendringerService, personhendelseService)
 
     @Test
     fun `Kun lønnsinntekt og ingen nye vedtak på bruker`() {

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.mockk
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.handler.PersonhendelseService
 import no.nav.familie.ef.personhendelse.inntekt.vedtak.EfVedtakRepository
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -18,7 +21,8 @@ class VedtakendringerServiceTest {
     private val oppgaveClient = mockk<OppgaveClient>()
     private val sakClient = mockk<SakClient>()
     private val inntektsendringerService = mockk<InntektsendringerService>()
-    val vedtakendringer = VedtakendringerService(efVedtakRepository, inntektClient, oppgaveClient, sakClient, inntektsendringerService)
+    private val personhendelseService = mockk<PersonhendelseService>()
+    private val vedtakendringer = VedtakendringerService(efVedtakRepository, inntektClient, oppgaveClient, sakClient, inntektsendringerService, personhendelseService)
 
     @Test
     fun `Kun lønnsinntekt og ingen nye vedtak på bruker`() {
@@ -28,6 +32,7 @@ class VedtakendringerServiceTest {
         Assertions.assertThat(vedtakendringer.harNyeVedtak(inntektshistorikkResponse)).isFalse
     }
 
+    @Test
     fun `Bruker har lønnsinntekt frem til forrige måned`() {
         val json: String = readResource("inntekt/InntekthistorikkLoennsinntektTilOffentligYtelseEksempel.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
@@ -86,6 +91,11 @@ class VedtakendringerServiceTest {
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
         val oppdatertInntektshistorikkResponse = oppdatertInntektshistorikkResponseTilNyereDato(inntektshistorikkResponse)
         Assertions.assertThat(vedtakendringer.harNyeVedtak(oppdatertInntektshistorikkResponse)).isFalse
+    }
+
+    @Test
+    fun `map stønadtype til behandlingstema`() {
+        Assertions.assertThat(StønadType.OVERGANGSSTØNAD.tilBehandlingstemaValue()).isEqualTo(Behandlingstema.Overgangsstønad.value)
     }
 
     fun oppdatertInntektshistorikkResponseTilNyereDato(inntektshistorikkResponse: InntektshistorikkResponse): InntektshistorikkResponse {

--- a/src/test/resources/inntekt/InntekthistorikkLoennsinntektOgOffentligYtelseEksempel.json
+++ b/src/test/resources/inntekt/InntekthistorikkLoennsinntektOgOffentligYtelseEksempel.json
@@ -20,7 +20,7 @@
                 "opptjeningsperiodeFom": "2021-01-01",
                 "utbetaltIMaaned": "2021-12",
                 "opplysningspliktig": {
-                  "identifikator": "928497704",
+                  "identifikator": "4",
                   "aktoerType": "ORGANISASJON"
                 },
                 "virksomhet": {

--- a/src/test/resources/inntekt/InntekthistorikkLoennsinntektOgOffentligYtelseEksempel.json
+++ b/src/test/resources/inntekt/InntekthistorikkLoennsinntektOgOffentligYtelseEksempel.json
@@ -1,0 +1,88 @@
+{
+  "aarMaanedHistorikk": {
+    "2021-12": {
+      "4": [
+        {
+          "versjon": 2,
+          "opplysningspliktig": "4",
+          "virksomhet": "4",
+          "innleveringstidspunkt": "2022-01-12T16:04:03.161",
+          "arbeidsInntektInformasjon": {
+            "inntektListe": [
+              {
+                "inntektType": "YTELSE_FRA_OFFENTLIGE",
+                "beloep": 20000,
+                "fordel": "kontantytelse",
+                "inntektskilde": "A-ordningen",
+                "inntektsperiodetype": "Maaned",
+                "inntektsstatus": "LoependeInnrapportert",
+                "leveringstidspunkt": "2022-01",
+                "opptjeningsperiodeFom": "2021-01-01",
+                "utbetaltIMaaned": "2021-12",
+                "opplysningspliktig": {
+                  "identifikator": "928497704",
+                  "aktoerType": "ORGANISASJON"
+                },
+                "virksomhet": {
+                  "identifikator": "4",
+                  "aktoerType": "ORGANISASJON"
+                },
+                "inntektsmottaker": {
+                  "identifikator": "1",
+                  "aktoerType": "NATURLIG_IDENT"
+                },
+                "inngaarIGrunnlagForTrekk": true,
+                "utloeserArbeidsgiveravgift": true,
+                "informasjonsstatus": "InngaarAlltid",
+                "beskrivelse": "venteloenn"
+              }
+            ]
+          }
+        }
+      ],
+      "5": [
+        {
+          "versjon": 2,
+          "opplysningspliktig": "5",
+          "virksomhet": "5",
+          "innleveringstidspunkt": "2021-12-23T11:40:27.177",
+          "arbeidsInntektInformasjon": {
+            "inntektListe": [
+              {
+                "inntektType": "LOENNSINNTEKT",
+                "beloep": 16000,
+                "fordel": "kontantytelse",
+                "inntektskilde": "A-ordningen",
+                "inntektsperiodetype": "Maaned",
+                "inntektsstatus": "LoependeInnrapportert",
+                "leveringstidspunkt": "2022-01",
+                "opptjeningsland": "NO",
+                "utbetaltIMaaned": "2020-07",
+                "opplysningspliktig": {
+                  "identifikator": "5",
+                  "aktoerType": "ORGANISASJON"
+                },
+                "virksomhet": {
+                  "identifikator": "5",
+                  "aktoerType": "ORGANISASJON"
+                },
+                "tilleggsinformasjon": {
+                  "kategori": "Nettoloennsordning"
+                },
+                "inntektsmottaker": {
+                  "identifikator": "1",
+                  "aktoerType": "NATURLIG_IDENT"
+                },
+                "inngaarIGrunnlagForTrekk": true,
+                "utloeserArbeidsgiveravgift": true,
+                "informasjonsstatus": "InngaarAlltid",
+                "beskrivelse": "fastloenn",
+                "skatteOgAvgiftsregel": "nettoloenn"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Det er flere forbedringer som burde gjøres og som ikke er glemt. Kommer til å lage ny favro-sak, men jeg prioriterer ikke gjøre det nå, fordi det er stort sett ytelsesforbedringer:
- Sende all informasjon som trengs på kafka for å slippe kall mot ef-sak
- Sette opp scheduler som kaller automatisk (til å starte med ønsker jeg å gjøre kallet manuelt for å i større grad ha kontroll og dobbeltsjekke litt i prod)
- Batche opp personer og kjøre i parallell