### PR TITLE
Første forbedring på oppgaveopprettelse for forelder-barn relasjon: I…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/ForelderBarnHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/ForelderBarnHandler.kt
@@ -21,7 +21,7 @@ class ForelderBarnHandler(val sakClient: SakClient) : PersonhendelseHandler {
     override fun lagOppgaveBeskrivelse(personhendelse: Personhendelse): OppgaveInformasjon {
         val personIdent = personhendelse.identerUtenAktørId().first()
         val nyeBarnForBruker = sakClient.finnNyeBarnForBruker(PersonIdent(personIdent))
-        if (nyeBarnForBruker.nyeBarn.isEmpty()) {
+        if (nyeBarnForBruker.nyeBarn.isEmpty() || personhendelse.forelderBarnRelasjon.relatertPersonsRolle != "BARN") {
             return IkkeOpprettOppgave
         }
 
@@ -40,7 +40,7 @@ class ForelderBarnHandler(val sakClient: SakClient) : PersonhendelseHandler {
                     "Vurder saken."
             )
         }
-        return OpprettOppgave("Bruker har fått et nytt/nye barn (${nyeBarnSomIkkeFinnesPåBehandlingen.separerteIdenter()}).")
+        return OpprettOppgave("Bruker har fått et nytt/nye barn (${nyeBarnSomIkkeFinnesPåBehandlingen.separerteIdenter()}) som ikke finnes på behandling.")
     }
 
     private fun NyeBarnDto.filtrerÅrsak(årsak: NyttBarnÅrsak) = this.nyeBarn.filter { it.årsak == årsak }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
@@ -102,9 +102,10 @@ class PersonhendelseService(
     private fun opphørEllerKorrigerOppgave(personhendelse: Personhendelse) {
         val hendelse = hentHendelse(personhendelse)
         if (hendelse == null) {
-            logger.info("Tidligere hendelse for personhendelse : ${personhendelse.hendelseId} ble ikke funnet")
-            val oppgaveId = opprettOppgaveMedBeskrivelse(personhendelse, personhendelse.finnesIngenHendelseBeskrivelse())
-            logger.info("Oppgave for at det ikke finnes hendelse opprettet med oppgaveId=$oppgaveId")
+            logger.warn(
+                "Tidligere hendelse for personhendelse : ${personhendelse.hendelseId} ble ikke funnet. " +
+                    personhendelse.finnesIngenHendelseBeskrivelse()
+            )
             return
         }
         val oppgave = hentOppgave(hendelse)

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/ForelderBarnHandlerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/ForelderBarnHandlerTest.kt
@@ -37,7 +37,7 @@ class ForelderBarnHandlerTest {
 
     private val slot = slot<OpprettOppgaveRequest>()
 
-    private val personhendelse = forelderBarnRelasjonHendelse("BARN")
+    private val personhendelse = forelderBarnRelasjonHendelse()
 
     private val barn1Fnr = "fnr"
     private val barn2Fnr = "fnr2"
@@ -64,7 +64,7 @@ class ForelderBarnHandlerTest {
         every { pdlClient.hentPerson(personIdent) } returns person
         service.håndterPersonhendelse(personhendelse)
         verify(exactly = 1) { oppgaveClient.opprettOppgave(any()) }
-        assertThat(slot.captured.beskrivelse).isEqualTo("Personhendelse: Bruker har fått et nytt/nye barn (fnr).")
+        assertThat(slot.captured.beskrivelse).isEqualTo("Personhendelse: Bruker har fått et nytt/nye barn (fnr) som ikke finnes på behandling.")
     }
 
     @Test
@@ -102,14 +102,14 @@ class ForelderBarnHandlerTest {
         every { sakClient.finnNyeBarnForBruker(any()) } returns NyeBarnDto(nyeBarn.toList())
     }
 
-    private fun forelderBarnRelasjonHendelse(minRolleForPerson: String): Personhendelse {
+    private fun forelderBarnRelasjonHendelse(): Personhendelse {
         val personhendelse = Personhendelse()
         personhendelse.personidenter = listOf(personIdent)
         personhendelse.opplysningstype = PersonhendelseType.FORELDERBARNRELASJON.hendelsetype
         personhendelse.forelderBarnRelasjon = no.nav.person.pdl.leesah.forelderbarnrelasjon.ForelderBarnRelasjon(
             personIdent,
-            "",
-            minRolleForPerson,
+            "BARN",
+            "MOR",
             null
         )
         personhendelse.hendelseId = UUID.randomUUID().toString()

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseServiceTest.kt
@@ -73,11 +73,11 @@ internal class PersonhendelseServiceTest {
     }
 
     @Test
-    fun `håndter personhendelse av typen annuller uten en tidligere hendelse, forvent oppgaveopprettelse`() {
+    fun `håndter personhendelse av typen annuller uten en tidligere hendelse, ikke opprett oppgave`() {
         val personhendelse = personhendelse(Endringstype.ANNULLERT)
         every { personhendelseRepository.hentHendelse(any()) }.returns(null)
         personhendelseService.håndterPersonhendelse(personhendelse)
-        verify { oppgaveClient.opprettOppgave(any()) }
+        verify(exactly = 0) { oppgaveClient.opprettOppgave(any()) }
     }
 
     @Test


### PR DESCRIPTION
…kke opprett oppgaver på annulleringer og opphør. Det holder med logging, for det blir for teknisk for saksbehandlere til at det er noe de får gjort noe med.

Legger til en sjekk på at en forelder-barn hendelse gjelder relasjon til barn, og ikke forelder. Har antakeligvis ikke lagd oppgave på dette før, men har det som en ekstra sikring.
Mulig det må gjøres noe sjekk på at barn det opprettes oppgave på skal være under 1 år, men avklarer dette med Mirja.