### PR TITLE
Definerer eksplisitt dei query-params som faktisk blir sendt inn for finnMappeRequest

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.getDataOrThrow
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -52,11 +51,11 @@ class OppgaveClient(
         return response.getDataOrThrow()
     }
 
-    fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
+    fun finnMapper(enhetsnummer: String, limit: Int = 1000): FinnMappeResponseDto {
         val response = getForEntity<Ressurs<FinnMappeResponseDto>>(
             UriComponentsBuilder.fromUri(URI.create("$oppgaveUrl/mappe/sok"))
-                .queryParam("enhetsnr", finnMappeRequest.enhetsnr)
-                .queryParam("limit", finnMappeRequest.limit)
+                .queryParam("enhetsnr", enhetsnummer)
+                .queryParam("limit", limit)
                 .build()
                 .toUri()
         )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
@@ -55,7 +55,8 @@ class OppgaveClient(
     fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
         val response = getForEntity<Ressurs<FinnMappeResponseDto>>(
             UriComponentsBuilder.fromUri(URI.create("$oppgaveUrl/mappe/sok"))
-                .queryParams(finnMappeRequest.toQueryParams())
+                .queryParam("enhetsnr", finnMappeRequest.enhetsnr)
+                .queryParam("limit", finnMappeRequest.limit)
                 .build()
                 .toUri()
         )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/handler/PersonhendelseService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.client.defaultOpprettOppgaveRequest
 import no.nav.familie.ef.personhendelse.personhendelsemapping.PersonhendelseRepository
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import no.nav.person.pdl.leesah.Endringstype
@@ -131,13 +130,7 @@ class PersonhendelseService(
     fun leggOppgaveIMappe(oppgaveId: Long) {
         val oppgave = oppgaveClient.finnOppgaveMedId(oppgaveId)
         if (oppgave.tildeltEnhetsnr == EF_ENHETNUMMER) { // Skjermede personer skal ikke puttes i mappe
-            val finnMappeRequest = FinnMappeRequest(
-                listOf(),
-                oppgave.tildeltEnhetsnr!!,
-                null,
-                1000
-            )
-            val mapperResponse = oppgaveClient.finnMapper(finnMappeRequest)
+            val mapperResponse = oppgaveClient.finnMapper(oppgave.tildeltEnhetsnr!!)
             val mappe = mapperResponse.mapper.find {
                 it.navn.contains("62") &&
                     it.navn.contains("Hendelser") &&


### PR DESCRIPTION
Tilretteleggjing for å fjerne toQueryParams-metoden, som fører med seg mykje unødig kompleksitet

Legg til rette for https://github.com/navikt/familie-kontrakter/pull/684