### PR TITLE
Oppretter oppgave ved opphør av sivilstand. Fjerner flere regler for …

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/SivilstandHandlerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/handler/SivilstandHandlerTest.kt
@@ -55,29 +55,6 @@ class SivilstandHandlerTest {
     }
 
     @Test
-    fun `Ikke opprett oppgave for sivilstand hendelse registrert partner dersom datoet for hendelsen er eldre enn 2 år`() {
-        val personhendelse = Personhendelse()
-        personhendelse.sivilstand = Sivilstand(
-            Sivilstandstype.REGISTRERT_PARTNER.name,
-            LocalDate.now().minusYears(2).minusMonths(1),
-            partnerPersonIdent,
-            LocalDate.now().minusYears(2).minusMonths(1)
-        )
-        personhendelse.opplysningstype = PersonhendelseType.SIVILSTAND.hendelsetype
-        personhendelse.personidenter = listOf(personIdent)
-        personhendelse.endringstype = Endringstype.OPPRETTET
-
-        every { sakClient.harLøpendeStønad(setOf(personIdent)) } returns true
-
-        val oppgaveRequestSlot = slot<OpprettOppgaveRequest>()
-        every { oppgaveClient.opprettOppgave(capture(oppgaveRequestSlot)) } returns 123L
-
-        service.håndterPersonhendelse(personhendelse)
-
-        assertThat(oppgaveRequestSlot.isCaptured).isFalse
-    }
-
-    @Test
     fun `Opprett oppgave for sivilstand hendelse registrert partner dersom person har løpende ef-sak`() {
         val personhendelse = Personhendelse()
         personhendelse.sivilstand = Sivilstand(
@@ -103,7 +80,7 @@ class SivilstandHandlerTest {
         assertThat(oppgaveRequestSlot.captured.oppgavetype).isEqualTo(Oppgavetype.VurderLivshendelse)
         val iDagNorskDatoformat = LocalDate.now().tilNorskDatoformat()
         assertThat(oppgaveRequestSlot.captured.beskrivelse)
-            .isEqualTo("Personhendelse: Sivilstand endret til \"Registrert partner\", gyldig fra og med dato: $iDagNorskDatoformat")
+            .isEqualTo("Personhendelse: Ny sivilstand av type \"Registrert partner\", gyldig fra og med dato: $iDagNorskDatoformat")
         assertThat(oppgaveRequestSlot.captured.ident?.ident).isEqualTo(personIdent)
     }
 }


### PR DESCRIPTION
…opphør av sivilstand. Det er ukjent hvilke hendelser som blir sendt i de forskjellige casene, og det er også begrensninger i muligheten til å teste dette i preprod. I denne PR'n fjernes derfor de fleste regler slik at det i større grad opprettes oppgaver sålenge en hendelse mottas og det er en løpende stønad på person. Dersom det blir meldt fra saksbehandlere at det blir opprettet for mange oppgaver i enkelte tilfeller, får det heller legges til regler i ettertid på det som blir meldt.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10446