### PR TITLE
Tar i bruk endret endepunkt, hvor personer med aktiv stønad som ikke …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
@@ -49,9 +49,9 @@ class SakClient(
             ?: throw Exception("Feil ved kall mot ef-sak ved henting av forventet inntekt for personer med aktiv stønad")
     }
 
-    fun hentPersonerMedAktivStønad(): List<String> {
+    fun hentPersonerMedAktivStønadIkkeManueltRevurdertSisteToMåneder(): List<String> {
         val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri)
-            .pathSegment("api/vedtak/personerMedAktivStonad")
+            .pathSegment("api/vedtak/personerMedAktivStonadIkkeManueltRevurdertSisteToMaaneder")
         val response = getForEntity<Ressurs<List<String>>>(uriComponentsBuilder.build().toUri())
         return response.data
             ?: throw Exception("Feil ved kall mot ef-sak ved henting av forventet inntekt for personer med aktiv stønad")

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -36,7 +36,7 @@ class VedtakendringerService(
     @Async
     fun beregnInntektsendringerOgLagreIDb(skalOppretteOppgave: Boolean = false) {
         logger.info("Starter beregning av inntektsendringer")
-        val personerMedAktivStønad = sakClient.hentPersonerMedAktivStønad()
+        val personerMedAktivStønad = sakClient.hentPersonerMedAktivStønadIkkeManueltRevurdertSisteToMåneder()
         efVedtakRepository.clearInntektsendringer()
         logger.info("Antall personer med aktiv stønad: ${personerMedAktivStønad.size}")
         var counter = 0


### PR DESCRIPTION
…har blitt manuelt revurdert siste to måneder for å få færre treff på inntektsendringer på 10%

### Hvorfor er dette nødvendig? ✨
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12220)
For å minimere antall treff på inntektsjekken, fjernes personer som har blitt manuelt revurdert siste to måneder

[PR](https://github.com/navikt/familie-ef-sak/pull/2138) for endret endepunkt i EF-SAK
