### PR TITLE
Beregn og lagre prosentvis endring i inntekt i inntektsjekk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektDomain.kt
@@ -54,10 +54,12 @@ data class Tilleggsinformasjon(
     val tilleggsinformasjonDetaljer: TilleggsinformasjonDetaljer?,
 )
 
-data class EndretInntekt(
-    val harEndretInntekt: Boolean,
-    val gjennomsnittligEndringProsent: Int,
-)
+data class Inntektsendring(
+    val toMånederTilbake: Int,
+    val forrigeMåned: Int,
+) {
+    fun harEndretInntekt() = toMånederTilbake >= 10 && forrigeMåned >= 10
+}
 
 enum class AktørType {
     AKTOER_ID,

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektDomain.kt
@@ -54,6 +54,11 @@ data class Tilleggsinformasjon(
     val tilleggsinformasjonDetaljer: TilleggsinformasjonDetaljer?,
 )
 
+data class EndretInntekt(
+    val harEndretInntekt: Boolean,
+    val gjennomsnittligEndringProsent: Int,
+)
+
 enum class AktørType {
     AKTOER_ID,
     NATURLIG_IDENT,

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektHistorikkDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektHistorikkDomain.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.YearMonth
 
 data class InntektshistorikkResponse(
-    val aarMaanedHistorikk: Map<String, Map<String, List<InntektVersjon>>> = emptyMap(), // <Year-month>, <orgnr, inntekt>
+    val aarMaanedHistorikk: Map<YearMonth, Map<String, List<InntektVersjon>>> = emptyMap(), // <Year-month>, <orgnr, inntekt>
 ) {
-    fun inntektForMåned(yearMonth: String) = aarMaanedHistorikk[yearMonth]?.values?.flatten() ?: emptyList()
+    fun inntektForMåned(yearMonth: YearMonth) = aarMaanedHistorikk[yearMonth]?.values?.flatten() ?: emptyList()
 
-    fun inntektEntryForMåned(yearMonth: String) = aarMaanedHistorikk[yearMonth] ?: emptyMap()
+    fun inntektEntryForMåned(yearMonth: YearMonth) = aarMaanedHistorikk[yearMonth] ?: emptyMap()
 }
 
 data class InntektVersjon(

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -15,21 +15,36 @@ class InntektsendringerService(
 
     private val halvtGrunnbeløpMånedlig = (106399 / 2) / 12
 
-    fun harEndretInntekt(inntektshistorikkResponse: InntektshistorikkResponse, forventetInntektForPerson: ForventetInntektForPerson): Boolean {
+    fun beregnEndretInntekt(inntektshistorikkResponse: InntektshistorikkResponse, forventetInntektForPerson: ForventetInntektForPerson): EndretInntekt {
         // hent alle registrerte vedtak som var på personen sist beregning
-        val nyesteRegistrerteInntekt = inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(1).toString())
-        val nestNyesteRegistrerteInntekt = inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(2).toString())
+        val nyesteRegistrerteInntekt =
+            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(1).toString())
+        val nestNyesteRegistrerteInntekt =
+            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(2).toString())
 
-        return har10ProsentHøyereInntektEnnForventet(nestNyesteRegistrerteInntekt, forventetInntektForPerson.personIdent, forventetInntektForPerson.forventetInntektToMånederTilbake) &&
-            har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt, forventetInntektForPerson.personIdent, forventetInntektForPerson.forventetInntektForrigeMåned)
+        val antallProsentToMånederTilbake = antallProsentHøyereInntektEnnForventet(
+            nestNyesteRegistrerteInntekt,
+            forventetInntektForPerson.personIdent,
+            forventetInntektForPerson.forventetInntektToMånederTilbake,
+        )
+        val antallProsentForrigeMåned = antallProsentHøyereInntektEnnForventet(
+            nyesteRegistrerteInntekt,
+            forventetInntektForPerson.personIdent,
+            forventetInntektForPerson.forventetInntektForrigeMåned,
+        )
+
+        return EndretInntekt(
+            antallProsentForrigeMåned >= 10 && antallProsentToMånederTilbake >= 10,
+            (antallProsentForrigeMåned + antallProsentToMånederTilbake) / 2,
+        )
     }
 
-    private fun har10ProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt: List<InntektVersjon>?, ident: String, forventetInntekt: Int?): Boolean {
+    private fun antallProsentHøyereInntektEnnForventet(nyesteRegistrerteInntekt: List<InntektVersjon>?, ident: String, forventetInntekt: Int?): Int {
         if (forventetInntekt == null || nyesteRegistrerteInntekt?.maxOfOrNull { it.versjon } == null) {
             secureLogger.warn("Ingen gjeldende inntekt funnet på person $ident har personen løpende stønad?")
-            return false
+            return 0
         }
-        if (forventetInntekt > 585000) return false // Ignorer alle med over 585000 i årsinntekt, da de har 0 i utbetaling.
+        if (forventetInntekt > 585000) return 0 // Ignorer alle med over 585000 i årsinntekt, da de har 0 i utbetaling.
         val månedligForventetInntekt = (forventetInntekt / 12)
 
         val orgNrToNyesteVersjonMap = nyesteRegistrerteInntekt.associate { it.opplysningspliktig to it.versjon }
@@ -39,9 +54,10 @@ class InntektsendringerService(
             ignorerteYtelserOgUtbetalinger.contains(it.beskrivelse) ||
                 (it.inntektType == InntektType.YTELSE_FRA_OFFENTLIGE && it.tilleggsinformasjon?.tilleggsinformasjonDetaljer?.detaljerType == "ETTERBETALINGSPERIODE")
         }.sumOf { it.beløp }
-        if (samletInntekt < halvtGrunnbeløpMånedlig) return false
+        if (samletInntekt < halvtGrunnbeløpMånedlig) return 0
         secureLogger.info("Samlet inntekt: $samletInntekt - månedlig forventet inntekt: $månedligForventetInntekt  (årlig: $forventetInntekt) for person $ident")
-        return samletInntekt >= (månedligForventetInntekt * 1.1) && samletInntekt > 0 // Må sjekke om samletInntekt er større enn 0 for å ikke få true dersom alle variabler er 0 (antakelig kun i test)
+        val antallProsentInntektEndret = (((samletInntekt / månedligForventetInntekt.toDouble()) * 100) - 100).toInt()
+        return antallProsentInntektEndret
     }
 
     // Ignorterte ytelser: AAP og Dagpenger er ignorert fordi de er variable. Alle uføre går under annet regelverk (samordning) og skal derfor ignoreres.

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -64,8 +64,13 @@ class VedtakendringerService(
         response: InntektshistorikkResponse,
     ) {
         val harNyeVedtak = harNyeVedtak(response)
-        val harEndretInntekt = inntektsendringerService.harEndretInntekt(response, forventetInntektForPerson)
-        efVedtakRepository.lagreInntektsendring(forventetInntektForPerson.personIdent, harNyeVedtak, harEndretInntekt)
+        val endretInntekt = inntektsendringerService.beregnEndretInntekt(response, forventetInntektForPerson)
+        efVedtakRepository.lagreInntektsendring(
+            forventetInntektForPerson.personIdent,
+            harNyeVedtak,
+            endretInntekt.harEndretInntekt,
+            endretInntekt.gjennomsnittligEndringProsent,
+        )
     }
 
     fun opprettOppgaverForInntektsendringer(skalOppretteOppgave: Boolean): Int {

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -68,8 +68,8 @@ class VedtakendringerService(
         efVedtakRepository.lagreInntektsendring(
             forventetInntektForPerson.personIdent,
             harNyeVedtak,
-            endretInntekt.harEndretInntekt,
-            endretInntekt.gjennomsnittligEndringProsent,
+            endretInntekt.toMånederTilbake,
+            endretInntekt.forrigeMåned,
         )
     }
 
@@ -77,7 +77,7 @@ class VedtakendringerService(
         val inntektsendringer = efVedtakRepository.hentInntektsendringer()
         if (skalOppretteOppgave) {
             inntektsendringer.forEach {
-                opprettOppgave(it.harNyttVedtak, it.harEndretInntekt, it.personIdent)
+                opprettOppgave(it.harNyttVedtak, it.inntektsendringToMånederTilbake, it.inntektsendringForrigeMåned, it.personIdent)
             }
         } else {
             logger.info("Ville opprettet inntektsendring-oppgave for ${inntektsendringer.size} personer")
@@ -88,9 +88,9 @@ class VedtakendringerService(
     fun harNyeVedtak(inntektshistorikkResponse: InntektshistorikkResponse): Boolean {
         // hent alle registrerte vedtak som var på personen sist beregning
         val nyesteRegistrerteInntekt =
-            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(1).toString())
+            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(1))
         val nestNyesteRegistrerteInntekt =
-            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(2).toString())
+            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(2))
 
         val antallOffentligeYtelserForNyeste = antallOffentligeYtelser(nyesteRegistrerteInntekt)
         val antallOffentligeYtelserForNestNyeste = antallOffentligeYtelser(nestNyesteRegistrerteInntekt)
@@ -137,11 +137,12 @@ class VedtakendringerService(
 
     private fun opprettOppgave(
         harNyeVedtak: Boolean,
-        harEndretInntekt: Boolean,
+        inntektsendringToMånederInntekt: Int,
+        inntektsendringForrigeMåned: Int,
         personident: String,
         stønadType: StønadType = StønadType.OVERGANGSSTØNAD,
     ) {
-        val oppgavetekst = lagOppgavetekst(harNyeVedtak, harEndretInntekt)
+        val oppgavetekst = lagOppgavetekst(harNyeVedtak, inntektsendringToMånederInntekt >= 10 && inntektsendringForrigeMåned >= 10)
         secureLogger.info("$personident - $oppgavetekst")
         val enhetsnummer =
             arbeidsfordelingClient.hentArbeidsfordelingEnhetId(personident)
@@ -167,13 +168,15 @@ class VedtakendringerService(
     }
 
     private fun lagOppgavetekst(harNyeVedtak: Boolean, harEndretInntekt: Boolean): String {
-        val måned = YearMonth.now().minusMonths(1).month.tilNorsk()
+        val forrigeMåned = YearMonth.now().minusMonths(1).month.tilNorsk()
+        val toMånederTilbake = YearMonth.now().minusMonths(2).month.tilNorsk()
+
         if (harNyeVedtak && harEndretInntekt) {
-            return "Person har fått utbetalt ny stønad fra NAV og har økt inntekt i $måned. Vurder om overgangsstønaden skal revurderes."
+            return "Person har fått utbetalt ny stønad fra NAV og har økt inntekt i $toMånederTilbake og $forrigeMåned. Vurder om overgangsstønaden skal revurderes."
         } else if (harNyeVedtak) {
-            return "Person har fått utbetalt ny stønad fra NAV i $måned. Vurder om overgangsstønaden skal revurderes."
+            return "Person har fått utbetalt ny stønad fra NAV i $forrigeMåned. Vurder om overgangsstønaden skal revurderes."
         } else {
-            return "Person har økt inntekt i $måned. Vurder om overgangsstønaden skal revurderes."
+            return "Person har økt inntekt i $toMånederTilbake og $forrigeMåned. Vurder om overgangsstønaden skal revurderes."
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -63,9 +63,9 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         namedParameterJdbcTemplate.update(sql, mapSqlParameterSource)
     }
 
-    fun lagreInntektsendring(personIdent: String, harNyeVedtak: Boolean, harEndretInntekt: Boolean) {
+    fun lagreInntektsendring(personIdent: String, harNyeVedtak: Boolean, harEndretInntekt: Boolean, inntektEndretProsent: Int) {
         val sql =
-            "INSERT INTO inntektsendringer VALUES(:id, :personIdent, :harNyeVedtak, :harEndretInntekt, :prosessertTid)" +
+            "INSERT INTO inntektsendringer VALUES(:id, :personIdent, :harNyeVedtak, :harEndretInntekt, :prosessertTid, :inntektEndretProsent)" +
                 " ON CONFLICT DO NOTHING"
         val params = MapSqlParameterSource(
             mapOf(
@@ -74,6 +74,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
                 "harNyeVedtak" to harNyeVedtak,
                 "harEndretInntekt" to harEndretInntekt,
                 "prosessertTid" to LocalDateTime.now(),
+                "inntektEndretProsent" to inntektEndretProsent,
             ),
         )
         namedParameterJdbcTemplate.update(sql, params)
@@ -90,6 +91,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
             rs.getBoolean("harNyttVedtak"),
             rs.getBoolean("harEndretInntekt"),
             rs.getObject("prosessert_tid", LocalDateTime::class.java),
+            rs.getInt("inntekt_endret_prosent"),
         )
     }
 
@@ -104,4 +106,5 @@ data class Inntektsendring(
     val harNyttVedtak: Boolean,
     val harEndretInntekt: Boolean,
     val prosessertTid: LocalDateTime,
+    val inntektEndretProsent: Int,
 )

--- a/src/main/resources/db/migration/V6__add_inntekt_endret_prosent.sql
+++ b/src/main/resources/db/migration/V6__add_inntekt_endret_prosent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE inntektsendringer ADD COLUMN inntekt_endret_prosent INT;

--- a/src/main/resources/db/migration/V6__add_inntekt_endret_prosent.sql
+++ b/src/main/resources/db/migration/V6__add_inntekt_endret_prosent.sql
@@ -1,1 +1,3 @@
-ALTER TABLE inntektsendringer ADD COLUMN inntekt_endret_prosent INT;
+ALTER TABLE inntektsendringer DROP COLUMN harendretinntekt;
+ALTER TABLE inntektsendringer ADD COLUMN inntekt_endret_to_maaneder_tilbake INT DEFAULT 0;
+ALTER TABLE inntektsendringer ADD COLUMN inntekt_endret_forrige_maaned INT DEFAULT 0;

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -18,7 +18,7 @@ class InntektsendringerServiceTest {
     private val oppgaveClient = mockk<OppgaveClient>()
     private val sakClient = mockk<SakClient>()
 
-    val inntektsendringer = InntektsendringerService(oppgaveClient, sakClient)
+    val inntektsendringerService = InntektsendringerService(oppgaveClient, sakClient)
     val forventetLønnsinntekt = 420000 // 35k pr mnd i eksempel json-fil
 
     @BeforeEach
@@ -81,23 +81,23 @@ class InntektsendringerServiceTest {
         val forventetInntektNiProsentLavere = (forventetLønnsinntekt * 0.91).toInt()
 
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forventetLønnsinntekt, forventetLønnsinntekt),
             ),
-        ).isFalse
+        ).isEqualTo(EndretInntekt(false, 0))
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
             ),
-        ).isTrue
+        ).isEqualTo(EndretInntekt(true, 11))
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("3", forventetInntektNiProsentLavere, forventetInntektNiProsentLavere),
             ),
-        ).isFalse
+        ).isEqualTo(EndretInntekt(false, 9))
     }
 
     @Test
@@ -133,10 +133,10 @@ class InntektsendringerServiceTest {
         val forventetInntektTiProsentLavere = (forventetLønnsinntekt * 0.9).toInt()
 
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
-            ),
+            ).harEndretInntekt,
         ).isFalse
     }
 
@@ -155,10 +155,10 @@ class InntektsendringerServiceTest {
         val forventetInntekt = 172_000
 
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("2", forventetInntekt, forventetInntekt),
-            ),
+            ).harEndretInntekt,
         ).isFalse
     }
 
@@ -213,10 +213,10 @@ class InntektsendringerServiceTest {
 
         val forHøyInntekt = 585001
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forHøyInntekt, forHøyInntekt),
-            ),
+            ).harEndretInntekt,
         ).isFalse
     }
 
@@ -271,10 +271,10 @@ class InntektsendringerServiceTest {
 
         val forventetInntekt = 30000
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forventetInntekt, forventetInntekt),
-            ),
+            ).harEndretInntekt,
         ).isFalse
     }
 
@@ -293,10 +293,10 @@ class InntektsendringerServiceTest {
 
         val forventetInntekt = 5000
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forventetInntekt, forventetInntekt),
-            ),
+            ).harEndretInntekt,
         ).isFalse
     }
 
@@ -350,10 +350,10 @@ class InntektsendringerServiceTest {
         )
 
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("3", forventetLønnsinntekt, forventetLønnsinntekt),
-            ),
+            ).harEndretInntekt,
         ).isFalse
     }
 
@@ -377,10 +377,10 @@ class InntektsendringerServiceTest {
 
         val forventetInntekt = 70000
         Assertions.assertThat(
-            inntektsendringer.harEndretInntekt(
+            inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("3", forventetInntekt, forventetInntekt),
-            ),
+            ).harEndretInntekt,
         ).isTrue
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -34,14 +34,14 @@ class InntektsendringerServiceTest {
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
         val nyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2022-01").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1)).first().arbeidsInntektInformasjon
         val nestNyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
                 Pair(
-                    YearMonth.now().minusMonths(1).toString(),
+                    YearMonth.now().minusMonths(1),
                     mapOf(
                         Pair(
                             "1",
@@ -58,7 +58,7 @@ class InntektsendringerServiceTest {
                     ),
                 ),
                 Pair(
-                    YearMonth.now().minusMonths(2).toString(),
+                    YearMonth.now().minusMonths(2),
                     mapOf(
                         Pair(
                             "1",
@@ -85,19 +85,19 @@ class InntektsendringerServiceTest {
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forventetLønnsinntekt, forventetLønnsinntekt),
             ),
-        ).isEqualTo(EndretInntekt(false, 0))
+        ).isEqualTo(Inntektsendring(0, 0))
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
             ),
-        ).isEqualTo(EndretInntekt(true, 11))
+        ).isEqualTo(Inntektsendring(11, 11))
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("3", forventetInntektNiProsentLavere, forventetInntektNiProsentLavere),
             ),
-        ).isEqualTo(EndretInntekt(false, 9))
+        ).isEqualTo(Inntektsendring(9, 9))
     }
 
     @Test
@@ -106,12 +106,12 @@ class InntektsendringerServiceTest {
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
         val inntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
                 Pair(
-                    YearMonth.now().minusMonths(1).toString(),
+                    YearMonth.now().minusMonths(1),
                     mapOf(
                         Pair(
                             "5",
@@ -136,20 +136,20 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isFalse
     }
 
     @Test
-    fun `Bruker med forventet inntekt, men har mer enn 10 prosent høyere inntekt med etterbetaling av utbetalinger fra offentlig ytelse, som skal ignoreres og derfor returnere false`() {
+    fun `Bruker med mer enn 10 prosent inntektsendring pga etterbetaling skal ignoreres`() {
         val json: String = readResource("inntekt/InntekthistorikkEtterbetalingSkalIgnoreres.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val inntektVersjonForNyesteMåned = inntektshistorikkResponse.inntektForMåned("2022-02")
+        val inntektVersjonForNyesteMåned = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 2))
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", inntektVersjonForNyesteMåned))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", inntektVersjonForNyesteMåned))),
             ),
         )
         val forventetInntekt = 172_000
@@ -158,7 +158,7 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("2", forventetInntekt, forventetInntekt),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isFalse
     }
 
@@ -168,14 +168,14 @@ class InntektsendringerServiceTest {
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
         val nyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2022-01").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1)).first().arbeidsInntektInformasjon
         val nestNyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
                 Pair(
-                    YearMonth.now().minusMonths(1).toString(),
+                    YearMonth.now().minusMonths(1),
                     mapOf(
                         Pair(
                             "1",
@@ -192,7 +192,7 @@ class InntektsendringerServiceTest {
                     ),
                 ),
                 Pair(
-                    YearMonth.now().minusMonths(2).toString(),
+                    YearMonth.now().minusMonths(2),
                     mapOf(
                         Pair(
                             "1",
@@ -216,7 +216,7 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forHøyInntekt, forHøyInntekt),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isFalse
     }
 
@@ -226,14 +226,14 @@ class InntektsendringerServiceTest {
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
         val nyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2022-01").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1)).first().arbeidsInntektInformasjon
         val nestNyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
                 Pair(
-                    YearMonth.now().minusMonths(1).toString(),
+                    YearMonth.now().minusMonths(1),
                     mapOf(
                         Pair(
                             "1",
@@ -250,7 +250,7 @@ class InntektsendringerServiceTest {
                     ),
                 ),
                 Pair(
-                    YearMonth.now().minusMonths(2).toString(),
+                    YearMonth.now().minusMonths(2),
                     mapOf(
                         Pair(
                             "1",
@@ -274,7 +274,7 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forventetInntekt, forventetInntekt),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isFalse
     }
 
@@ -283,11 +283,11 @@ class InntektsendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkUførepensjonFraAndreEnnFolketrygden.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-01")
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1))
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
             ),
         )
 
@@ -296,7 +296,7 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("1", forventetInntekt, forventetInntekt),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isFalse
     }
 
@@ -306,14 +306,14 @@ class InntektsendringerServiceTest {
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
         val nyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2022-02").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 2)).first().arbeidsInntektInformasjon
         val nestNyesteArbeidsInntektInformasjonIEksempelJson =
-            inntektshistorikkResponse.inntektForMåned("2022-01").first().arbeidsInntektInformasjon
+            inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
                 Pair(
-                    YearMonth.now().minusMonths(1).toString(),
+                    YearMonth.now().minusMonths(1),
                     mapOf(
                         Pair(
                             "1",
@@ -330,7 +330,7 @@ class InntektsendringerServiceTest {
                     ),
                 ),
                 Pair(
-                    YearMonth.now().minusMonths(2).toString(),
+                    YearMonth.now().minusMonths(2),
                     mapOf(
                         Pair(
                             "1",
@@ -353,7 +353,7 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("3", forventetLønnsinntekt, forventetLønnsinntekt),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isFalse
     }
 
@@ -362,14 +362,14 @@ class InntektsendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkFrilanser.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-03")
-        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-03")
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 3))
+        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 3))
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
                 Pair(
-                    YearMonth.now().minusMonths(2).toString(),
+                    YearMonth.now().minusMonths(2),
                     mapOf(Pair("1", nestNyesteArbeidsInntektInformasjonIEksempelJson)),
                 ),
             ),
@@ -380,7 +380,7 @@ class InntektsendringerServiceTest {
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
                 ForventetInntektForPerson("3", forventetInntekt, forventetInntekt),
-            ).harEndretInntekt,
+            ).harEndretInntekt(),
         ).isTrue
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
@@ -36,13 +36,13 @@ class VedtakendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkLoennsinntektEksempel.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-01").first().arbeidsInntektInformasjon
-        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1)).first().arbeidsInntektInformasjon
+        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", listOf(InntektVersjon(nyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
-                Pair(YearMonth.now().minusMonths(2).toString(), mapOf(Pair("1", listOf(InntektVersjon(nestNyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", listOf(InntektVersjon(nyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
+                Pair(YearMonth.now().minusMonths(2), mapOf(Pair("1", listOf(InntektVersjon(nestNyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
             ),
         )
 
@@ -54,13 +54,13 @@ class VedtakendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkEtterbetalingSkalIgnoreres.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-02")
-        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-01")
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 2))
+        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 1))
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
-                Pair(YearMonth.now().minusMonths(2).toString(), mapOf(Pair("1", nestNyesteArbeidsInntektInformasjonIEksempelJson))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
+                Pair(YearMonth.now().minusMonths(2), mapOf(Pair("1", nestNyesteArbeidsInntektInformasjonIEksempelJson))),
             ),
         )
 
@@ -72,13 +72,13 @@ class VedtakendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkMedForeldrepenger.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2023-01")
-        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2022-12")
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2023, 1))
+        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2022, 12))
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
-                Pair(YearMonth.now().minusMonths(2).toString(), mapOf(Pair("1", nestNyesteArbeidsInntektInformasjonIEksempelJson))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", nyesteArbeidsInntektInformasjonIEksempelJson))),
+                Pair(YearMonth.now().minusMonths(2), mapOf(Pair("1", nestNyesteArbeidsInntektInformasjonIEksempelJson))),
             ),
         )
 
@@ -90,13 +90,13 @@ class VedtakendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkLoennsinntektTilOffentligYtelseEksempel.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
-        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2021-11").first().arbeidsInntektInformasjon
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
+        val nestNyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 11)).first().arbeidsInntektInformasjon
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", listOf(InntektVersjon(nyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
-                Pair(YearMonth.now().minusMonths(2).toString(), mapOf(Pair("1", listOf(InntektVersjon(nestNyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", listOf(InntektVersjon(nyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
+                Pair(YearMonth.now().minusMonths(2), mapOf(Pair("1", listOf(InntektVersjon(nestNyesteArbeidsInntektInformasjonIEksempelJson, null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
             ),
         )
 
@@ -108,15 +108,15 @@ class VedtakendringerServiceTest {
         val json: String = readResource("inntekt/InntekthistorikkLoennsinntektTilOffentligYtelseEksempel.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
-        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned("2021-12").first().arbeidsInntektInformasjon
+        val nyesteArbeidsInntektInformasjonIEksempelJson = inntektshistorikkResponse.inntektForMåned(YearMonth.of(2021, 12)).first().arbeidsInntektInformasjon
 
         val toUtbetalingerSammeYtelse = listOf(nyesteArbeidsInntektInformasjonIEksempelJson.inntektListe!!.first(), nyesteArbeidsInntektInformasjonIEksempelJson.inntektListe?.first()!!.copy(beløp = 10000))
 
         val oppdatertDatoInntektshistorikkResponse = InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), mapOf(Pair("1", listOf(InntektVersjon(ArbeidsInntekthistorikkInformasjon(null, null, null, toUtbetalingerSammeYtelse), null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
+                Pair(YearMonth.now().minusMonths(1), mapOf(Pair("1", listOf(InntektVersjon(ArbeidsInntekthistorikkInformasjon(null, null, null, toUtbetalingerSammeYtelse), null, "innleveringstidspunkt", "opplysningspliktig", 1))))),
                 Pair(
-                    YearMonth.now().minusMonths(2).toString(),
+                    YearMonth.now().minusMonths(2),
                     mapOf(
                         Pair(
                             "1",
@@ -153,11 +153,11 @@ class VedtakendringerServiceTest {
     }
 
     fun oppdatertInntektshistorikkResponseTilNyereDato(inntektshistorikkResponse: InntektshistorikkResponse): InntektshistorikkResponse {
-        val keys = inntektshistorikkResponse.aarMaanedHistorikk.keys.sortedBy { YearMonth.parse(it) }
+        val keys = inntektshistorikkResponse.aarMaanedHistorikk.keys.sortedBy { it }
         return InntektshistorikkResponse(
             linkedMapOf(
-                Pair(YearMonth.now().minusMonths(1).toString(), inntektshistorikkResponse.inntektEntryForMåned(keys.first())),
-                Pair(YearMonth.now().minusMonths(2).toString(), inntektshistorikkResponse.inntektEntryForMåned(keys.last())),
+                Pair(YearMonth.now().minusMonths(1), inntektshistorikkResponse.inntektEntryForMåned(keys.first())),
+                Pair(YearMonth.now().minusMonths(2), inntektshistorikkResponse.inntektEntryForMåned(keys.last())),
             ),
         )
     }

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -66,15 +66,15 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     fun `lagre inntektsendringer`() {
-        efVedtakRepository.lagreInntektsendring("1", true, false, 5)
+        efVedtakRepository.lagreInntektsendring("1", true, 10, 5)
         var hentInntektsendringer = efVedtakRepository.hentInntektsendringer()
         Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)
 
         val inntektsendring = hentInntektsendringer.first()
         Assertions.assertThat(inntektsendring.personIdent).isEqualTo("1")
         Assertions.assertThat(inntektsendring.harNyttVedtak).isTrue
-        Assertions.assertThat(inntektsendring.harEndretInntekt).isFalse
-        Assertions.assertThat(inntektsendring.inntektEndretProsent).isEqualTo(5)
+        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake).isEqualTo(10)
+        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned).isEqualTo(5)
 
         efVedtakRepository.clearInntektsendringer()
         hentInntektsendringer = efVedtakRepository.hentInntektsendringer()

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -66,7 +66,7 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     fun `lagre inntektsendringer`() {
-        efVedtakRepository.lagreInntektsendring("1", true, false)
+        efVedtakRepository.lagreInntektsendring("1", true, false, 5)
         var hentInntektsendringer = efVedtakRepository.hentInntektsendringer()
         Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)
 
@@ -74,6 +74,7 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
         Assertions.assertThat(inntektsendring.personIdent).isEqualTo("1")
         Assertions.assertThat(inntektsendring.harNyttVedtak).isTrue
         Assertions.assertThat(inntektsendring.harEndretInntekt).isFalse
+        Assertions.assertThat(inntektsendring.inntektEndretProsent).isEqualTo(5)
 
         efVedtakRepository.clearInntektsendringer()
         hentInntektsendringer = efVedtakRepository.hentInntektsendringer()


### PR DESCRIPTION
**Hvorfor gjøres dette?**
Ikke laget eget Favro-kort på det, men det er ønsket fra fag at det beregnes hvor mye inntekt endres i prosent, slik at de med høyest avvik på inntekt revurderes først for å unngå feilutbetalinger