### PR TITLE
Skal legge med behandlingsnummer header ved kall til PDL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <graphql-kotlin-maven-plugin.version>6.4.0</graphql-kotlin-maven-plugin.version>
         <graphql-kotlin.version>3.5.0</graphql-kotlin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-        <kontrakter.version>3.0_20230404163639_edb8619-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
         <token-validation-spring-test.version>3.0.4</token-validation-spring-test.version> <!-- Denne burde være samme versjon som i felles -->
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlClient.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.personhendelse.generated.HentPerson
 import no.nav.familie.ef.personhendelse.generated.hentidenter.IdentInformasjon
 import no.nav.familie.ef.personhendelse.generated.hentperson.Person
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.Tema
 import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -50,6 +51,7 @@ class PdlClient(
 private fun httpHeadersPdl(): HttpHeaders {
     return HttpHeaders().apply {
         add("Tema", "ENF")
+        add("behandlingsnummer", Tema.ENF.behandlingsnummer)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlError.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlError.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ef.personhendelse.client.pdl
 
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?,
+    val extensions: PdlErrorExtensions?,
 )
 
-data class PdlExtensions(val code: String?) {
+data class PdlErrorExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlResponse.kt
@@ -3,13 +3,19 @@ package no.nav.familie.ef.personhendelse.client.pdl
 data class PdlResponse<T>(
     val data: T,
     val errors: List<PdlError>?,
+    val extensions: PdlExtensions?,
 ) {
 
     fun harFeil(): Boolean {
         return errors != null && errors.isNotEmpty()
     }
-
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
+    }
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
     }
 }
+
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlResponseHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/pdl/PdlResponseHandler.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
+val logger: Logger = LoggerFactory.getLogger(PdlClient::class.java)
 
 inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
     ident: String?,
@@ -16,6 +17,10 @@ inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
         }
         secureLogger.error("Feil ved henting av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
+    }
+    if (pdlResponse.harAdvarsel()) {
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
     }
 
     val data = dataMapper.invoke(pdlResponse.data)


### PR DESCRIPTION
Hvorfor ?

PDL gjør endringer mot en mere fingranulert tilgangsstyring, og ønsker at konsumentene skal legge på en header med behandlingsnummer fra enhetskatalogen. Vi ønsker også å logge advarsler fra PDL, og ikke bare feil.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402