### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -23,11 +23,9 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 1024Mi
-      cpu: 1500m
     requests:
       memory: 512Mi
       cpu: 500m

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -23,11 +23,9 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 1024Mi
-      cpu: 1500m
     requests:
       memory: 512Mi
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)