### PR TITLE
Vedtaksendringer - lagre hvilke vedtak som er nye

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -63,9 +63,9 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         namedParameterJdbcTemplate.update(sql, mapSqlParameterSource)
     }
 
-    fun lagreInntektsendring(personIdent: String, harNyeVedtak: Boolean, inntektsendringToMånederTilbake: Int, inntektsendringForrigeMåned: Int) {
+    fun lagreInntektsendring(personIdent: String, harNyeVedtak: Boolean, inntektsendringToMånederTilbake: Int, inntektsendringForrigeMåned: Int, nyYtelse: String?) {
         val sql =
-            "INSERT INTO inntektsendringer VALUES(:id, :personIdent, :harNyeVedtak, :prosessertTid, :inntektsendringToMånederTilbake, :inntektsendringForrigeMåned)" +
+            "INSERT INTO inntektsendringer VALUES(:id, :personIdent, :harNyeVedtak, :prosessertTid, :inntektsendringToMånederTilbake, :inntektsendringForrigeMåned, :nyYtelse)" +
                 " ON CONFLICT DO NOTHING"
         val params = MapSqlParameterSource(
             mapOf(
@@ -75,6 +75,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
                 "prosessertTid" to LocalDateTime.now(),
                 "inntektsendringToMånederTilbake" to inntektsendringToMånederTilbake,
                 "inntektsendringForrigeMåned" to inntektsendringForrigeMåned,
+                "nyYtelse" to nyYtelse,
             ),
         )
         namedParameterJdbcTemplate.update(sql, params)
@@ -92,6 +93,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
             rs.getObject("prosessert_tid", LocalDateTime::class.java),
             rs.getInt("inntekt_endret_to_maaneder_tilbake"),
             rs.getInt("inntekt_endret_forrige_maaned"),
+            rs.getString("ny_ytelse_type"),
         )
     }
 
@@ -107,4 +109,5 @@ data class Inntektsendring(
     val prosessertTid: LocalDateTime,
     val inntektsendringToMånederTilbake: Int,
     val inntektsendringForrigeMåned: Int,
+    val nyYtelse: String?,
 )

--- a/src/main/resources/db/migration/V7__ny_ytelse_type.sql
+++ b/src/main/resources/db/migration/V7__ny_ytelse_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE inntektsendringer ADD COLUMN ny_ytelse_type VARCHAR;

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
@@ -68,7 +68,7 @@ class VedtakendringerServiceTest {
     }
 
     @Test
-    fun `Bruker har fått foreldrepenger som skal filtreres bort, da det blir oppdaget gjennom EksternVedtak-lytter`() {
+    fun `Bruker har fått foreldrepenger i nyeste måned`() {
         val json: String = readResource("inntekt/InntekthistorikkMedForeldrepenger.json")
         val inntektshistorikkResponse = objectMapper.readValue<InntektshistorikkResponse>(json)
 
@@ -82,7 +82,7 @@ class VedtakendringerServiceTest {
             ),
         )
 
-        Assertions.assertThat(vedtakendringer.harNyeVedtak(oppdatertDatoInntektshistorikkResponse)).isFalse
+        Assertions.assertThat(vedtakendringer.harNyeVedtak(oppdatertDatoInntektshistorikkResponse)).isTrue
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -66,7 +66,7 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     fun `lagre inntektsendringer`() {
-        efVedtakRepository.lagreInntektsendring("1", true, 10, 5)
+        efVedtakRepository.lagreInntektsendring("1", true, 10, 5, "SYKEPENGER, UFØRETRYGD")
         var hentInntektsendringer = efVedtakRepository.hentInntektsendringer()
         Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)
 
@@ -75,6 +75,7 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
         Assertions.assertThat(inntektsendring.harNyttVedtak).isTrue
         Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake).isEqualTo(10)
         Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned).isEqualTo(5)
+        Assertions.assertThat(inntektsendring.nyYtelse).isEqualTo("SYKEPENGER, UFØRETRYGD")
 
         efVedtakRepository.clearInntektsendringer()
         hentInntektsendringer = efVedtakRepository.hentInntektsendringer()


### PR DESCRIPTION
**Hvorfor?**
Som del av innsiktsarbeid sammen med avdelingslederne er det ønskelig at det blir tallfestet hvilke ytelser som er nye, og at alle ytelser tas med i vedtaksendringer-sjekken. Lagrer derfor ned hvilke vedtak som anses som nye. Anså det som greit at det kan bli satt flere ytelser i samme kolonne, da det bare skal brukes til å rapportere videre.

Edit: testet i preprod