### PR TITLE
Beregn feilutbetaling og lagre inntekt for 4 måneder tilbake

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
@@ -86,4 +86,5 @@ data class ForventetInntektForPerson(
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
     val forventetInntektTreMånederTilbake: Int?,
+    val forventetInntektFireMånederTilbake: Int?,
 )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektDomain.kt
@@ -54,17 +54,6 @@ data class Tilleggsinformasjon(
     val tilleggsinformasjonDetaljer: TilleggsinformasjonDetaljer?,
 )
 
-data class Inntektsendring(
-    val treMånederTilbake: Int,
-    val toMånederTilbake: Int,
-    val forrigeMåned: Int,
-    val beløpTreMånederTilbake: Int,
-    val beløpToMånederTilbake: Int,
-    val beløpForrigeMåned: Int,
-) {
-    fun harEndretInntekt() = treMånederTilbake >= 10 && toMånederTilbake >= 10 && forrigeMåned >= 10
-}
-
 enum class AktørType {
     AKTOER_ID,
     NATURLIG_IDENT,

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -5,6 +5,8 @@ import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.client.pdl.secureLogger
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.YearMonth
 
 @Service
@@ -13,7 +15,9 @@ class InntektsendringerService(
     val sakClient: SakClient,
 ) {
 
-    private val halvtGrunnbeløpMånedlig = (118620 / 2) / 12
+    private val grunnbeløp = 118_620
+    private val halvtGrunnbeløpMånedlig = (grunnbeløp / 2) / 12
+    private val reduksjonsfaktor = BigDecimal(0.45)
 
     fun beregnEndretInntekt(inntektshistorikkResponse: InntektshistorikkResponse, forventetInntektForPerson: ForventetInntektForPerson): Inntektsendring {
         // hent alle registrerte vedtak som var på personen sist beregning
@@ -23,6 +27,14 @@ class InntektsendringerService(
             inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(2))
         val inntektTreMånederTilbake =
             inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(3))
+        val inntektFireMånederTilbake =
+            inntektshistorikkResponse.inntektForMåned(YearMonth.now().minusMonths(4))
+
+        val inntektsendringFireMånederTilbake = beregnInntektsendring(
+            inntektFireMånederTilbake,
+            forventetInntektForPerson.personIdent,
+            forventetInntektForPerson.forventetInntektTreMånederTilbake,
+        )
 
         val inntektsendringTreMånederTilbake = beregnInntektsendring(
             inntektTreMånederTilbake,
@@ -41,21 +53,20 @@ class InntektsendringerService(
         )
 
         return Inntektsendring(
-            treMånederTilbake = inntektsendringTreMånederTilbake.prosent,
-            toMånederTilbake = inntektsendringToMånederTilbake.prosent,
-            forrigeMåned = inntektsendringForrigeMåned.prosent,
-            beløpTreMånederTilbake = inntektsendringTreMånederTilbake.beløp,
-            beløpToMånederTilbake = inntektsendringToMånederTilbake.beløp,
-            beløpForrigeMåned = inntektsendringForrigeMåned.beløp,
+            fireMånederTilbake = inntektsendringFireMånederTilbake,
+            treMånederTilbake = inntektsendringTreMånederTilbake,
+            toMånederTilbake = inntektsendringToMånederTilbake,
+            forrigeMåned = inntektsendringForrigeMåned,
         )
     }
 
     private fun beregnInntektsendring(nyesteRegistrerteInntekt: List<InntektVersjon>?, ident: String, forventetInntekt: Int?): BeregningResultat {
         if (forventetInntekt == null || nyesteRegistrerteInntekt?.maxOfOrNull { it.versjon } == null) {
             secureLogger.warn("Ingen gjeldende inntekt funnet på person $ident har personen løpende stønad?")
-            return BeregningResultat(0, 0)
+            return BeregningResultat(0, 0, 0)
         }
-        if (forventetInntekt > 585000) return BeregningResultat(0, 0) // Ignorer alle med over 585000 i årsinntekt, da de har 0 i utbetaling.
+
+        if (forventetInntekt > 652000) return BeregningResultat(0, 0, 0) // Ignorer alle med over 652000 i årsinntekt, da de har 0 i utbetaling.
         val månedligForventetInntekt = (forventetInntekt / 12)
 
         val orgNrToNyesteVersjonMap = nyesteRegistrerteInntekt.associate { it.opplysningspliktig to it.versjon }
@@ -67,13 +78,38 @@ class InntektsendringerService(
                 (it.inntektType == InntektType.YTELSE_FRA_OFFENTLIGE && it.tilleggsinformasjon?.tilleggsinformasjonDetaljer?.detaljerType == "ETTERBETALINGSPERIODE")
         }.sumOf { it.beløp }
 
-        if (samletInntekt < halvtGrunnbeløpMånedlig) return BeregningResultat(0, 0)
+        if (samletInntekt < halvtGrunnbeløpMånedlig) return BeregningResultat(0, 0, 0)
 
         secureLogger.info("Samlet inntekt: $samletInntekt - månedlig forventet inntekt: $månedligForventetInntekt  (årlig: $forventetInntekt) for person $ident")
         val inntektsendringProsent = (((samletInntekt - månedligForventetInntekt) / månedligForventetInntekt.toDouble()) * 100).toInt()
-        val beløp = samletInntekt - månedligForventetInntekt
-        if (månedligForventetInntekt == 0) return BeregningResultat(beløp, 100) // Prioriterer personer registrert med uredusert stønad, men har samlet inntekt over 1/2 G
-        return BeregningResultat(beløp, inntektsendringProsent)
+        val endretInntektBeløp = samletInntekt - månedligForventetInntekt
+        val feilutbetaling = beregnFeilutbetaling(månedligForventetInntekt, samletInntekt)
+        if (månedligForventetInntekt == 0) return BeregningResultat(endretInntektBeløp, 100, feilutbetaling) // Prioriterer personer registrert med uredusert stønad, men har samlet inntekt over 1/2 G
+        return BeregningResultat(endretInntektBeløp, inntektsendringProsent, feilutbetaling)
+    }
+
+    fun beregnFeilutbetaling(forventetInntekt: Int, samletInntekt: Int): Int {
+        return beregnUtbetaling(samletInntekt) - beregnUtbetaling(forventetInntekt)
+    }
+
+    private fun beregnUtbetaling(inntekt: Int): Int {
+        val avkortningPerMåned = beregnAvkortning(inntekt).setScale(0, RoundingMode.HALF_DOWN)
+
+        val fullOvergangsstønadPerMåned =
+            BigDecimal(grunnbeløp).multiply(BigDecimal(2.25)).divide(BigDecimal(12)).setScale(0, RoundingMode.HALF_EVEN)
+
+        val utbetaling = fullOvergangsstønadPerMåned.subtract(avkortningPerMåned).setScale(0, RoundingMode.HALF_UP)
+
+        return if (utbetaling <= BigDecimal.ZERO) 0 else utbetaling.intValueExact()
+    }
+
+    private fun beregnAvkortning(inntekt: Int): BigDecimal {
+        val inntektOverHalveGrunnbeløp = BigDecimal(inntekt).subtract(BigDecimal(grunnbeløp).multiply(BigDecimal(0.5)))
+        return if (inntektOverHalveGrunnbeløp > BigDecimal.ZERO) {
+            inntektOverHalveGrunnbeløp.multiply(reduksjonsfaktor).setScale(5, RoundingMode.HALF_DOWN)
+        } else {
+            BigDecimal.ZERO
+        }
     }
 
     // Ignorterte ytelser: Alle uføre går under annet regelverk (samordning) og skal derfor ignoreres.
@@ -86,7 +122,17 @@ class InntektsendringerService(
     )
 }
 
+data class Inntektsendring(
+    val fireMånederTilbake: BeregningResultat,
+    val treMånederTilbake: BeregningResultat,
+    val toMånederTilbake: BeregningResultat,
+    val forrigeMåned: BeregningResultat,
+) {
+    fun harEndretInntekt() = fireMånederTilbake.prosent >= 10 && treMånederTilbake.prosent >= 10 && toMånederTilbake.prosent >= 10 && forrigeMåned.prosent >= 10
+}
+
 data class BeregningResultat(
     val beløp: Int,
     val prosent: Int,
+    val feilutbetaling: Int,
 )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ef.personhendelse.inntekt.vedtak
 
+import no.nav.familie.ef.personhendelse.inntekt.BeregningResultat
+import no.nav.familie.ef.personhendelse.inntekt.Inntektsendring
 import no.nav.familie.kontrakter.felles.ef.EnsligForsørgerVedtakhendelse
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
@@ -63,57 +65,83 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         namedParameterJdbcTemplate.update(sql, mapSqlParameterSource)
     }
 
-    fun lagreInntektsendring(
+    fun lagreVedtakOgInntektsendringForPersonIdent(
         personIdent: String,
         harNyeVedtak: Boolean,
-        inntektsendringTreMånederTilbake: Int,
-        inntektsendringToMånederTilbake: Int,
-        inntektsendringForrigeMåned: Int,
-        nyYtelse: String?,
-        inntektsendringTreMånederTilbakeBeløp: Int,
-        inntektsendringToMånederTilbakeBeløp: Int,
-        inntektsendringForrigeMånedBeløp: Int,
+        nyeYtelser: String?,
+        inntektsendring: Inntektsendring,
     ) {
         val sql =
-            "INSERT INTO inntektsendringer VALUES(:id, :personIdent, :harNyeVedtak, :prosessertTid, " +
-                ":inntektsendringToMånederTilbake, :inntektsendringForrigeMåned, :nyYtelse, " +
-                ":inntektsendringTreMånederTilbakeBeløp, :inntektsendringToMånederTilbakeBeløp, :inntektsendringForrigeMånedBeløp, :inntektsendringTreMånederTilbake)" +
-                " ON CONFLICT DO NOTHING"
+            "INSERT INTO inntektsendringer(" +
+                "id, person_ident, harnyttvedtak, ny_ytelse_type, prosessert_tid, " +
+                "inntekt_endret_fire_maaneder_tilbake, inntekt_endret_tre_maaneder_tilbake, inntekt_endret_to_maaneder_tilbake, inntekt_endret_forrige_maaned, " +
+                "inntekt_endret_fire_maaneder_tilbake_belop, inntekt_endret_tre_maaneder_tilbake_belop, inntekt_endret_to_maaneder_tilbake_belop, inntekt_endret_forrige_maaned_belop," +
+                "feilutbetaling_fire_maaneder_tilbake, feilutbetaling_tre_maaneder_tilbake, feilutbetaling_to_maaneder_tilbake, feilutbetaling_forrige_maaned" +
+                ") VALUES" +
+                "(:id, :personIdent, :harNyeVedtak, :nyeYtelser, :prosessertTid, " +
+                ":inntektsendringFireMånederTilbake, :inntektsendringTreMånederTilbake, :inntektsendringToMånederTilbake, :inntektsendringForrigeMåned, " +
+                ":inntektsendringFireMånederTilbakeBeløp, :inntektsendringTreMånederTilbakeBeløp, :inntektsendringToMånederTilbakeBeløp, :inntektsendringForrigeMånedBeløp, " +
+                ":feilutbetalingFireMånederTilbake, :feilutbetalingTreMånederTilbake, :feilutbetalingToMånederTilbake, :feilutbetalingForrigeMåned) " +
+                "ON CONFLICT DO NOTHING"
         val params = MapSqlParameterSource(
             mapOf(
                 "id" to UUID.randomUUID(),
                 "personIdent" to personIdent,
                 "harNyeVedtak" to harNyeVedtak,
+                "nyeYtelser" to nyeYtelser,
                 "prosessertTid" to LocalDateTime.now(),
-                "inntektsendringTreMånederTilbake" to inntektsendringTreMånederTilbake,
-                "inntektsendringToMånederTilbake" to inntektsendringToMånederTilbake,
-                "inntektsendringForrigeMåned" to inntektsendringForrigeMåned,
-                "nyYtelse" to nyYtelse,
-                "inntektsendringTreMånederTilbakeBeløp" to inntektsendringTreMånederTilbakeBeløp,
-                "inntektsendringToMånederTilbakeBeløp" to inntektsendringToMånederTilbakeBeløp,
-                "inntektsendringForrigeMånedBeløp" to inntektsendringForrigeMånedBeløp,
+                "inntektsendringFireMånederTilbake" to inntektsendring.fireMånederTilbake.prosent,
+                "inntektsendringTreMånederTilbake" to inntektsendring.treMånederTilbake.prosent,
+                "inntektsendringToMånederTilbake" to inntektsendring.toMånederTilbake.prosent,
+                "inntektsendringForrigeMåned" to inntektsendring.forrigeMåned.prosent,
+                "inntektsendringFireMånederTilbakeBeløp" to inntektsendring.fireMånederTilbake.beløp,
+                "inntektsendringTreMånederTilbakeBeløp" to inntektsendring.treMånederTilbake.beløp,
+                "inntektsendringToMånederTilbakeBeløp" to inntektsendring.toMånederTilbake.beløp,
+                "inntektsendringForrigeMånedBeløp" to inntektsendring.forrigeMåned.beløp,
+                "feilutbetalingFireMånederTilbake" to inntektsendring.fireMånederTilbake.feilutbetaling,
+                "feilutbetalingTreMånederTilbake" to inntektsendring.treMånederTilbake.feilutbetaling,
+                "feilutbetalingToMånederTilbake" to inntektsendring.toMånederTilbake.feilutbetaling,
+                "feilutbetalingForrigeMåned" to inntektsendring.forrigeMåned.feilutbetaling,
             ),
         )
         namedParameterJdbcTemplate.update(sql, params)
     }
 
-    fun hentInntektsendringer(): List<Inntektsendring> {
-        val sql = "SELECT * FROM inntektsendringer WHERE harNyttVedtak = true OR (inntekt_endret_tre_maaneder_tilbake >= 10 AND inntekt_endret_to_maaneder_tilbake >= 10 AND inntekt_endret_forrige_maaned >= 10)"
+    fun hentInntektOgVedtakEndring(): List<InntektOgVedtakEndring> {
+        val sql = "SELECT * FROM inntektsendringer WHERE harNyttVedtak = true OR " +
+            "(inntekt_endret_fire_maaneder_tilbake >= 10 AND " +
+            "inntekt_endret_tre_maaneder_tilbake >= 10 AND " +
+            "inntekt_endret_to_maaneder_tilbake >= 10 AND " +
+            "inntekt_endret_forrige_maaned >= 10)"
         return namedParameterJdbcTemplate.query(sql, inntektsendringerMapper)
     }
 
     private val inntektsendringerMapper = { rs: ResultSet, _: Int ->
-        Inntektsendring(
+        InntektOgVedtakEndring(
             rs.getString("person_ident"),
             rs.getBoolean("harNyttVedtak"),
             rs.getObject("prosessert_tid", LocalDateTime::class.java),
-            rs.getInt("inntekt_endret_tre_maaneder_tilbake"),
-            rs.getInt("inntekt_endret_to_maaneder_tilbake"),
-            rs.getInt("inntekt_endret_forrige_maaned"),
+            BeregningResultat(
+                rs.getInt("inntekt_endret_fire_maaneder_tilbake_belop"),
+                rs.getInt("inntekt_endret_fire_maaneder_tilbake"),
+                rs.getInt("feilutbetaling_fire_maaneder_tilbake"),
+            ),
+            BeregningResultat(
+                rs.getInt("inntekt_endret_tre_maaneder_tilbake_belop"),
+                rs.getInt("inntekt_endret_tre_maaneder_tilbake"),
+                rs.getInt("feilutbetaling_tre_maaneder_tilbake"),
+            ),
+            BeregningResultat(
+                rs.getInt("inntekt_endret_to_maaneder_tilbake_belop"),
+                rs.getInt("inntekt_endret_to_maaneder_tilbake"),
+                rs.getInt("feilutbetaling_to_maaneder_tilbake"),
+            ),
+            BeregningResultat(
+                rs.getInt("inntekt_endret_forrige_maaned_belop"),
+                rs.getInt("inntekt_endret_forrige_maaned"),
+                rs.getInt("feilutbetaling_forrige_maaned"),
+            ),
             rs.getString("ny_ytelse_type"),
-            rs.getInt("inntekt_endret_tre_maaneder_tilbake_belop"),
-            rs.getInt("inntekt_endret_to_maaneder_tilbake_belop"),
-            rs.getInt("inntekt_endret_forrige_maaned_belop"),
         )
     }
 
@@ -123,15 +151,13 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
     }
 }
 
-data class Inntektsendring(
+data class InntektOgVedtakEndring(
     val personIdent: String,
-    val harNyttVedtak: Boolean,
+    val harNyeVedtak: Boolean,
     val prosessertTid: LocalDateTime,
-    val inntektsendringTreMånederTilbake: Int,
-    val inntektsendringToMånederTilbake: Int,
-    val inntektsendringForrigeMåned: Int,
-    val nyYtelse: String?,
-    val inntektsendringTreMånederTilbakeBeløp: Int,
-    val inntektsendringToMånederTilbakeBeløp: Int,
-    val inntektsendringForrigeMånedBeløp: Int,
+    val inntektsendringFireMånederTilbake: BeregningResultat,
+    val inntektsendringTreMånederTilbake: BeregningResultat,
+    val inntektsendringToMånederTilbake: BeregningResultat,
+    val inntektsendringForrigeMåned: BeregningResultat,
+    val nyeYtelser: String?,
 )

--- a/src/main/resources/db/migration/V10__inntekt_fire_mnd_tilbake.sql
+++ b/src/main/resources/db/migration/V10__inntekt_fire_mnd_tilbake.sql
@@ -1,0 +1,6 @@
+ALTER TABLE inntektsendringer ADD COLUMN inntekt_endret_fire_maaneder_tilbake INT DEFAULT 0;
+ALTER TABLE inntektsendringer ADD COLUMN inntekt_endret_fire_maaneder_tilbake_belop INT DEFAULT 0;
+ALTER TABLE inntektsendringer ADD COLUMN feilutbetaling_fire_maaneder_tilbake INT DEFAULT 0;
+ALTER TABLE inntektsendringer ADD COLUMN feilutbetaling_tre_maaneder_tilbake INT DEFAULT 0;
+ALTER TABLE inntektsendringer ADD COLUMN feilutbetaling_to_maaneder_tilbake INT DEFAULT 0;
+ALTER TABLE inntektsendringer ADD COLUMN feilutbetaling_forrige_maaned INT DEFAULT 0;

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -91,6 +91,23 @@ class InntektsendringerServiceTest {
                         ),
                     ),
                 ),
+                Pair(
+                    YearMonth.now().minusMonths(4),
+                    mapOf(
+                        Pair(
+                            "1",
+                            listOf(
+                                InntektVersjon(
+                                    nestNyesteArbeidsInntektInformasjonIEksempelJson,
+                                    null,
+                                    "innleveringstidspunkt",
+                                    "opplysningspliktig",
+                                    1,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
             ),
         )
 
@@ -100,21 +117,22 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("1", forventetLønnsinntekt, forventetLønnsinntekt, forventetLønnsinntekt),
+                ForventetInntektForPerson("1", forventetLønnsinntekt, forventetLønnsinntekt, forventetLønnsinntekt, forventetLønnsinntekt),
             ),
-        ).isEqualTo(Inntektsendring(0, 0, 0, 0, 0, 0))
+        ).isEqualTo(inntektsendring())
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
+                ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere, forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
             ),
-        ).isEqualTo(Inntektsendring(11, 11, 11, 3500, 3500, 3500))
+        ).isEqualTo(inntektsendring(3500, 11))
+
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("3", forventetInntektNiProsentLavere, forventetInntektNiProsentLavere, forventetInntektNiProsentLavere),
+                ForventetInntektForPerson("3", forventetInntektNiProsentLavere, forventetInntektNiProsentLavere, forventetInntektNiProsentLavere, forventetInntektNiProsentLavere),
             ),
-        ).isEqualTo(Inntektsendring(9, 9, 9, 3150, 3150, 3150))
+        ).isEqualTo(inntektsendring(3150, 9))
     }
 
     @Test
@@ -152,7 +170,7 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
+                ForventetInntektForPerson("2", forventetInntektTiProsentLavere, forventetInntektTiProsentLavere, forventetInntektTiProsentLavere, forventetInntektTiProsentLavere),
             ).harEndretInntekt(),
         ).isFalse
     }
@@ -174,7 +192,7 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("2", forventetInntekt, forventetInntekt, forventetInntekt),
+                ForventetInntektForPerson("2", forventetInntekt, forventetInntekt, forventetInntekt, forventetInntekt),
             ).harEndretInntekt(),
         ).isFalse
     }
@@ -232,7 +250,7 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("1", forHøyInntekt, forHøyInntekt, forHøyInntekt),
+                ForventetInntektForPerson("1", forHøyInntekt, forHøyInntekt, forHøyInntekt, forHøyInntekt),
             ).harEndretInntekt(),
         ).isFalse
     }
@@ -290,7 +308,7 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("1", forventetInntekt, forventetInntekt, forventetInntekt),
+                ForventetInntektForPerson("1", forventetInntekt, forventetInntekt, forventetInntekt, forventetInntekt),
             ).harEndretInntekt(),
         ).isFalse
     }
@@ -312,7 +330,7 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("1", forventetInntekt, forventetInntekt, forventetInntekt),
+                ForventetInntektForPerson("1", forventetInntekt, forventetInntekt, forventetInntekt, forventetInntekt),
             ).harEndretInntekt(),
         ).isFalse
     }
@@ -369,7 +387,7 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("3", forventetLønnsinntekt, forventetLønnsinntekt, forventetLønnsinntekt),
+                ForventetInntektForPerson("3", forventetLønnsinntekt, forventetLønnsinntekt, forventetLønnsinntekt, forventetLønnsinntekt),
             ).harEndretInntekt(),
         ).isFalse
     }
@@ -394,6 +412,10 @@ class InntektsendringerServiceTest {
                     YearMonth.now().minusMonths(3),
                     mapOf(Pair("1", treMånederTilbakeArbeidsInntektInformasjonIEksempelJson)),
                 ),
+                Pair(
+                    YearMonth.now().minusMonths(4),
+                    mapOf(Pair("1", treMånederTilbakeArbeidsInntektInformasjonIEksempelJson)),
+                ),
             ),
         )
 
@@ -401,12 +423,21 @@ class InntektsendringerServiceTest {
         Assertions.assertThat(
             inntektsendringerService.beregnEndretInntekt(
                 oppdatertDatoInntektshistorikkResponse,
-                ForventetInntektForPerson("3", forventetInntekt, forventetInntekt, forventetInntekt),
+                ForventetInntektForPerson("3", forventetInntekt, forventetInntekt, forventetInntekt, forventetInntekt),
             ).harEndretInntekt(),
         ).isTrue
     }
 
     fun readResource(name: String): String {
         return this::class.java.classLoader.getResource(name)!!.readText(StandardCharsets.UTF_8)
+    }
+
+    fun inntektsendring(beløp: Int = 0, prosent: Int = 0): Inntektsendring {
+        val beregningsResultat = beregningResultat(beløp, prosent)
+        return Inntektsendring(beregningsResultat, beregningsResultat, beregningsResultat, beregningsResultat)
+    }
+
+    fun beregningResultat(beløp: Int = 0, prosent: Int = 0): BeregningResultat {
+        return BeregningResultat(beløp, prosent, 0)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ef.personhendelse.inntekt.vedtak
 
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
+import no.nav.familie.ef.personhendelse.inntekt.BeregningResultat
+import no.nav.familie.ef.personhendelse.inntekt.Inntektsendring
 import no.nav.familie.kontrakter.felles.ef.EnsligForsørgerVedtakhendelse
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.assertj.core.api.Assertions
@@ -66,23 +68,39 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     fun `lagre inntektsendringer`() {
-        efVedtakRepository.lagreInntektsendring("1", true, 15, 10, 5, "SYKEPENGER, UFØRETRYGD", 150, 250, 350)
-        var hentInntektsendringer = efVedtakRepository.hentInntektsendringer()
+        efVedtakRepository.lagreVedtakOgInntektsendringForPersonIdent(
+            "1",
+            true,
+            "SYKEPENGER, UFØRETRYGD",
+            Inntektsendring(
+                BeregningResultat(150, 15, 100),
+                BeregningResultat(250, 10, 50),
+                BeregningResultat(350, 5, 25),
+                BeregningResultat(500, 1, 12),
+            ),
+        )
+        var hentInntektsendringer = efVedtakRepository.hentInntektOgVedtakEndring()
         Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)
 
         val inntektsendring = hentInntektsendringer.first()
         Assertions.assertThat(inntektsendring.personIdent).isEqualTo("1")
-        Assertions.assertThat(inntektsendring.harNyttVedtak).isTrue
-        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake).isEqualTo(15)
-        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake).isEqualTo(10)
-        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned).isEqualTo(5)
-        Assertions.assertThat(inntektsendring.nyYtelse).isEqualTo("SYKEPENGER, UFØRETRYGD")
-        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbakeBeløp).isEqualTo(150)
-        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbakeBeløp).isEqualTo(250)
-        Assertions.assertThat(inntektsendring.inntektsendringForrigeMånedBeløp).isEqualTo(350)
+        Assertions.assertThat(inntektsendring.harNyeVedtak).isTrue
+        Assertions.assertThat(inntektsendring.nyeYtelser).isEqualTo("SYKEPENGER, UFØRETRYGD")
+        Assertions.assertThat(inntektsendring.inntektsendringFireMånederTilbake.beløp).isEqualTo(150)
+        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake.beløp).isEqualTo(250)
+        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.beløp).isEqualTo(350)
+        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.beløp).isEqualTo(500)
+        Assertions.assertThat(inntektsendring.inntektsendringFireMånederTilbake.prosent).isEqualTo(15)
+        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake.prosent).isEqualTo(10)
+        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.prosent).isEqualTo(5)
+        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.prosent).isEqualTo(1)
+        Assertions.assertThat(inntektsendring.inntektsendringFireMånederTilbake.feilutbetaling).isEqualTo(100)
+        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake.feilutbetaling).isEqualTo(50)
+        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.feilutbetaling).isEqualTo(25)
+        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.feilutbetaling).isEqualTo(12)
 
         efVedtakRepository.clearInntektsendringer()
-        hentInntektsendringer = efVedtakRepository.hentInntektsendringer()
+        hentInntektsendringer = efVedtakRepository.hentInntektOgVedtakEndring()
         Assertions.assertThat(hentInntektsendringer.isEmpty()).isTrue
     }
 }


### PR DESCRIPTION
Feilutbetaling skal beregnes for å prioritere best mulig hvilke saker som burde revurderes som følge av for høy inntekt.

Implementerer også lagring av inntekt 4 mnd tilbake, da det er ønsket fra saksbehandlere. Tilhørende PR i ef-sak: https://github.com/navikt/familie-ef-sak/pull/2449