### PR TITLE
Ignorer duplikate hendelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
@@ -42,9 +42,7 @@ class PersonhendelseListener(
                 "Leser personhendelse med hendelseId=${personhendelse.hendelseId} " +
                     "tidligereHendelseId=${personhendelse.tidligereHendelseId}",
             )
-            if (!personidenter.firstOrNull().isNullOrBlank() &&
-                !personhendelseService.harHåndtertHendelse(personhendelse.hendelseId)
-            ) {
+            if (!personidenter.firstOrNull().isNullOrBlank()) {
                 personhendelseService.håndterPersonhendelse(personhendelse)
             } else {
                 if (env != "dev") throw RuntimeException("Hendelse uten personIdent mottatt for hendelseId: ${personhendelse.hendelseId}")

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
@@ -43,7 +43,9 @@ class PersonhendelseListener(
                     "tidligereHendelseId=${personhendelse.tidligereHendelseId}",
             )
             if (!personidenter.firstOrNull().isNullOrBlank()) {
-                personhendelseService.håndterPersonhendelse(personhendelse)
+                if (!personhendelseService.harHåndtertHendelse(personhendelse.hendelseId)) {
+                    personhendelseService.håndterPersonhendelse(personhendelse)
+                }
             } else {
                 if (env != "dev") throw RuntimeException("Hendelse uten personIdent mottatt for hendelseId: ${personhendelse.hendelseId}")
             }


### PR DESCRIPTION
På grunn av en problemer med db hos PDL, må de sende ut hendelser på nytt fra fredag. Ignorerer nå duplikate hendelsesIds. Kommer til å ta inn igjen denne koden etter at personhendelse har lest siste meldingen, da vi ønsker å feile dersom det skulle skje i andre tilfeller.
https://nav-it.slack.com/archives/C020Q1K6EAY/p1699349632203809