### PR TITLE
Opprett oppgave inntektsendringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
@@ -69,6 +69,7 @@ class OppgaveClient(
         oppgave: Oppgave,
         mappenavnInneholder: String = "Hendelser",
     ) {
+        log.info("Mapper: ${mapperResponse.mapper}")
         val mappe = mapperResponse.mapper.find {
             it.navn.contains(mappenavnInneholder, true)
             !it.navn.contains("EF Sak", true)

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
@@ -51,12 +51,12 @@ class OppgaveClient(
         return response.getDataOrThrow()
     }
 
-    fun leggOppgaveIMappe(oppgaveId: Long) {
+    fun leggOppgaveIMappe(oppgaveId: Long, mappenavnInneholder: String = "Hendelser") {
         val oppgave = finnOppgaveMedId(oppgaveId)
         if (oppgave.tildeltEnhetsnr == EF_ENHETNUMMER) { // Skjermede personer skal ikke puttes i mappe
             val mapperResponse = finnMapper(oppgave.tildeltEnhetsnr!!)
             try {
-                oppdaterOppgaveMedMappe(mapperResponse, oppgave)
+                oppdaterOppgaveMedMappe(mapperResponse, oppgave, mappenavnInneholder)
             } catch (e: Exception) {
                 log.error("Feil under knytning av mappe til oppgave - se securelogs for stacktrace")
                 secureLogger.error("Feil under knytning av mappe til oppgave", e)
@@ -67,12 +67,12 @@ class OppgaveClient(
     private fun oppdaterOppgaveMedMappe(
         mapperResponse: FinnMappeResponseDto,
         oppgave: Oppgave,
+        mappenavnInneholder: String = "Hendelser",
     ) {
         val mappe = mapperResponse.mapper.find {
-            it.navn.contains("62") &&
-                it.navn.contains("Hendelser") &&
-                !it.navn.contains("EF Sak", true)
-        } ?: error("Fant ikke mappe 62 Hendelser for uplassert oppgave")
+            it.navn.contains(mappenavnInneholder, true)
+            !it.navn.contains("EF Sak", true)
+        } ?: error("Fant ikke mappe som inneholder mappenavn $mappenavnInneholder for uplassert oppgave")
         oppdaterOppgave(oppgave.copy(mappeId = mappe.id.toLong()))
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
@@ -71,7 +71,7 @@ class OppgaveClient(
     ) {
         log.info("Mapper: ${mapperResponse.mapper}")
         val mappe = mapperResponse.mapper.find {
-            it.navn.contains(mappenavnInneholder, true)
+            it.navn.contains(mappenavnInneholder, true) &&
             !it.navn.contains("EF Sak", true)
         } ?: error("Fant ikke mappe som inneholder mappenavn $mappenavnInneholder for uplassert oppgave")
         oppdaterOppgave(oppgave.copy(mappeId = mappe.id.toLong()))

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/OppgaveClient.kt
@@ -69,10 +69,9 @@ class OppgaveClient(
         oppgave: Oppgave,
         mappenavnInneholder: String = "Hendelser",
     ) {
-        log.info("Mapper: ${mapperResponse.mapper}")
         val mappe = mapperResponse.mapper.find {
             it.navn.contains(mappenavnInneholder, true) &&
-            !it.navn.contains("EF Sak", true)
+                !it.navn.contains("EF Sak", true)
         } ?: error("Fant ikke mappe som inneholder mappenavn $mappenavnInneholder for uplassert oppgave")
         oppdaterOppgave(oppgave.copy(mappeId = mappe.id.toLong()))
     }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -157,7 +157,7 @@ class VedtakendringerService(
             ),
         )
         secureLogger.info("Opprettet oppgave for person ${inntektOgVedtakEndring.personIdent} med id: $oppgaveId")
-        oppgaveClient.leggOppgaveIMappe(oppgaveId, "Inntektskontroll")
+        oppgaveClient.leggOppgaveIMappe(oppgaveId, "63 Inntektskontroll")
     }
 
     fun lagOppgavetekstForInntektsendring(inntektOgVedtakEndring: InntektOgVedtakEndring): String {
@@ -170,7 +170,7 @@ class VedtakendringerService(
 
         val periodeTekst =
             "FOM ${årMånedProsessert.minusMonths(5).norskFormat()} - TOM ${årMånedProsessert.minusMonths(1).norskFormat()}"
-        val oppgavetekst = " Uttrekksperiode: $periodeTekst \n" +
+        val oppgavetekst = "Uttrekksperiode: $periodeTekst \n" +
             "Beregnet feilutbetaling i uttrekksperioden: ${totalFeilutbetaling.tusenskille()} kroner "
         return oppgavetekst
     }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -157,7 +157,7 @@ class VedtakendringerService(
             ),
         )
         secureLogger.info("Opprettet oppgave for person ${inntektOgVedtakEndring.personIdent} med id: $oppgaveId")
-        oppgaveClient.leggOppgaveIMappe(oppgaveId, "63 Inntektskontroll")
+        oppgaveClient.leggOppgaveIMappe(oppgaveId, "63") //Inntektskontroll
     }
 
     fun lagOppgavetekstForInntektsendring(inntektOgVedtakEndring: InntektOgVedtakEndring): String {
@@ -169,7 +169,7 @@ class VedtakendringerService(
         val årMånedProsessert = YearMonth.from(inntektOgVedtakEndring.prosessertTid)
 
         val periodeTekst =
-            "FOM ${årMånedProsessert.minusMonths(5).norskFormat()} - TOM ${årMånedProsessert.minusMonths(1).norskFormat()}"
+            "FOM ${årMånedProsessert.minusMonths(4).norskFormat()} - TOM ${årMånedProsessert.minusMonths(1).norskFormat()}"
         val oppgavetekst = "Uttrekksperiode: $periodeTekst \n" +
             "Beregnet feilutbetaling i uttrekksperioden: ${totalFeilutbetaling.tusenskille()} kroner "
         return oppgavetekst

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -157,7 +157,7 @@ class VedtakendringerService(
             ),
         )
         secureLogger.info("Opprettet oppgave for person ${inntektOgVedtakEndring.personIdent} med id: $oppgaveId")
-        oppgaveClient.leggOppgaveIMappe(oppgaveId, "63") //Inntektskontroll
+        oppgaveClient.leggOppgaveIMappe(oppgaveId, "63") // Inntektskontroll
     }
 
     fun lagOppgavetekstForInntektsendring(inntektOgVedtakEndring: InntektOgVedtakEndring): String {

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -107,12 +107,13 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         namedParameterJdbcTemplate.update(sql, params)
     }
 
-    fun hentInntektOgVedtakEndring(): List<InntektOgVedtakEndring> {
-        val sql = "SELECT * FROM inntektsendringer WHERE harNyttVedtak = true OR " +
+    fun hentInntektsendringerSomSkalHaOppgave(): List<InntektOgVedtakEndring> {
+        val sql = "SELECT * FROM inntektsendringer WHERE " +
             "(inntekt_endret_fire_maaneder_tilbake >= 10 AND " +
             "inntekt_endret_tre_maaneder_tilbake >= 10 AND " +
             "inntekt_endret_to_maaneder_tilbake >= 10 AND " +
-            "inntekt_endret_forrige_maaned >= 10)"
+            "inntekt_endret_forrige_maaned >= 10) AND " +
+            "(feilutbetaling_fire_maaneder_tilbake + feilutbetaling_tre_maaneder_tilbake + feilutbetaling_to_maaneder_tilbake + feilutbetaling_forrige_maaned) > 20000"
         return namedParameterJdbcTemplate.query(sql, inntektsendringerMapper)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerServiceTest.kt
@@ -6,12 +6,14 @@ import no.nav.familie.ef.personhendelse.client.ArbeidsfordelingClient
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.inntekt.vedtak.EfVedtakRepository
+import no.nav.familie.ef.personhendelse.inntekt.vedtak.InntektOgVedtakEndring
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 class VedtakendringerServiceTest {
@@ -150,6 +152,25 @@ class VedtakendringerServiceTest {
     @Test
     fun `map stønadtype til behandlingstema`() {
         Assertions.assertThat(StønadType.OVERGANGSSTØNAD.tilBehandlingstemaValue()).isEqualTo(Behandlingstema.Overgangsstønad.value)
+    }
+
+    @Test
+    fun `lagOppgavetekstForInntektsendring - sjekk tusenskille på feiltubetalingsbeløp og norsk format på år-måned`() {
+        val oppgavetekst = vedtakendringer.lagOppgavetekstForInntektsendring(
+            InntektOgVedtakEndring(
+                "1",
+                false,
+                LocalDateTime.of(2023, 11, 8, 5, 0),
+                BeregningResultat(1, 1, 1),
+                BeregningResultat(2, 2, 2),
+                BeregningResultat(3, 3, 3),
+                BeregningResultat(4, 4, 40000),
+                null,
+            ),
+        )
+
+        Assertions.assertThat(oppgavetekst.contains("Beregnet feilutbetaling i uttrekksperioden: 40 006 kroner "))
+        Assertions.assertThat(oppgavetekst.contains("FOM 06.2023 - TOM 10.2023"))
     }
 
     fun oppdatertInntektshistorikkResponseTilNyereDato(inntektshistorikkResponse: InntektshistorikkResponse): InntektshistorikkResponse {

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -67,19 +67,31 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
     }
 
     @Test
-    fun `lagre inntektsendringer`() {
+    fun `lagre inntektsendringer og hent ut de som skal ha oppgave`() {
         efVedtakRepository.lagreVedtakOgInntektsendringForPersonIdent(
             "1",
             true,
             "SYKEPENGER, UFØRETRYGD",
             Inntektsendring(
-                BeregningResultat(150, 15, 100),
-                BeregningResultat(250, 10, 50),
-                BeregningResultat(350, 5, 25),
-                BeregningResultat(500, 1, 12),
+                BeregningResultat(150, 15, 10000),
+                BeregningResultat(250, 10, 5000),
+                BeregningResultat(350, 25, 2500),
+                BeregningResultat(500, 35, 12000),
             ),
         )
-        var hentInntektsendringer = efVedtakRepository.hentInntektOgVedtakEndring()
+
+        efVedtakRepository.lagreVedtakOgInntektsendringForPersonIdent(
+            "2",
+            false,
+            null,
+            Inntektsendring(
+                BeregningResultat(1500, 15, 100),
+                BeregningResultat(2500, 5, 50),
+                BeregningResultat(3500, 25, 25),
+                BeregningResultat(15000, 35, 12),
+            ),
+        )
+        var hentInntektsendringer = efVedtakRepository.hentInntektsendringerSomSkalHaOppgave()
         Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)
 
         val inntektsendring = hentInntektsendringer.first()
@@ -92,15 +104,15 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
         Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.beløp).isEqualTo(500)
         Assertions.assertThat(inntektsendring.inntektsendringFireMånederTilbake.prosent).isEqualTo(15)
         Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake.prosent).isEqualTo(10)
-        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.prosent).isEqualTo(5)
-        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.prosent).isEqualTo(1)
-        Assertions.assertThat(inntektsendring.inntektsendringFireMånederTilbake.feilutbetaling).isEqualTo(100)
-        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake.feilutbetaling).isEqualTo(50)
-        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.feilutbetaling).isEqualTo(25)
-        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.feilutbetaling).isEqualTo(12)
+        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.prosent).isEqualTo(25)
+        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.prosent).isEqualTo(35)
+        Assertions.assertThat(inntektsendring.inntektsendringFireMånederTilbake.feilutbetaling).isEqualTo(10000)
+        Assertions.assertThat(inntektsendring.inntektsendringTreMånederTilbake.feilutbetaling).isEqualTo(5000)
+        Assertions.assertThat(inntektsendring.inntektsendringToMånederTilbake.feilutbetaling).isEqualTo(2500)
+        Assertions.assertThat(inntektsendring.inntektsendringForrigeMåned.feilutbetaling).isEqualTo(12000)
 
         efVedtakRepository.clearInntektsendringer()
-        hentInntektsendringer = efVedtakRepository.hentInntektOgVedtakEndring()
+        hentInntektsendringer = efVedtakRepository.hentInntektsendringerSomSkalHaOppgave()
         Assertions.assertThat(hentInntektsendringer.isEmpty()).isTrue
     }
 }


### PR DESCRIPTION
Det skal opprettes oppgaver på personer med 20 000 kr eller mer i total feilutbetaling over de fire siste månedene. I november vil det si i perioden juli til og med oktober.

Oppgavene er spesifisert slik:
Tema: Enslig mor eller far
Oppgavetype: Vurder inntekt
Gjelder: blank
Ruting: enhetsmappe 63 Inntektskontroll

Testet i preprod:
![Screenshot 2023-11-08 at 14 57 31](https://github.com/navikt/familie-ef-personhendelse/assets/42737566/82ce472b-d573-47a9-a83c-f12a796f7b7a)
