### PR TITLE
Sjekk inntekt siste 3 mnd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
@@ -59,7 +59,7 @@ class SakClient(
     fun hentPersonerMedAktivStønadIkkeManueltRevurdertSisteMåneder(antallMåneder: Int = 3): List<String> {
         val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri)
             .pathSegment("api/vedtak/personerMedAktivStonadIkkeManueltRevurdertSisteMaaneder")
-            .queryParam("antallMaaneder", 4)
+            .queryParam("antallMaaneder", antallMåneder)
         val response = getForEntity<Ressurs<List<String>>>(uriComponentsBuilder.build().toUri())
         return response.data
             ?: throw Exception("Feil ved kall mot ef-sak ved henting av forventet inntekt for personer med aktiv stønad")

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerService.kt
@@ -38,7 +38,7 @@ class VedtakendringerService(
     @Async
     fun beregnInntektsendringerOgLagreIDb() {
         logger.info("Starter beregning av inntektsendringer")
-        val personerMedAktivStønad = sakClient.hentPersonerMedAktivStønadIkkeManueltRevurdertSisteMåneder(4)
+        val personerMedAktivStønad = sakClient.hentPersonerMedAktivStønadIkkeManueltRevurdertSisteMåneder(3)
         efVedtakRepository.clearInntektsendringer()
         logger.info("Antall personer med aktiv stønad: ${personerMedAktivStønad.size}")
         var counter = 0

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -109,8 +109,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
 
     fun hentInntektsendringerSomSkalHaOppgave(): List<InntektOgVedtakEndring> {
         val sql = "SELECT * FROM inntektsendringer WHERE " +
-            "(inntekt_endret_fire_maaneder_tilbake >= 10 AND " +
-            "inntekt_endret_tre_maaneder_tilbake >= 10 AND " +
+            "(inntekt_endret_tre_maaneder_tilbake >= 10 AND " +
             "inntekt_endret_to_maaneder_tilbake >= 10 AND " +
             "inntekt_endret_forrige_maaned >= 10) AND " +
             "(feilutbetaling_fire_maaneder_tilbake + feilutbetaling_tre_maaneder_tilbake + feilutbetaling_to_maaneder_tilbake + feilutbetaling_forrige_maaned) > 20000"


### PR DESCRIPTION
Saksbehandlere ønsket å vite hvor mange det ville blitt dersom det bare er inntektsendring siste 3 mnd og ikke siste 4 mnd.

Ved spørring i db ser det ut til at det blir minimum 44 brukere totalt som ville fått oppgave, minus de som allerede er lagd fra forrige kjøring, forutsatt at totalt feilutbetalingsbeløp blir satt ned til 15 000,-, noe som tidligere var 20 000,-.
For at det skal bli helt riktig må hele inntektsberegningen kjøres på nytt for å sjekke alle som ikke har vært revurdert siste 3 måneder. Endrer derfor bare på kallet mot ef-sak som finner alle som har aktive stønad og som ikke er revurdert siste 3 måneder. Det vil bli med flere i uttrekket denne gangen, da forrige kjøring krevde at det ikke var revurdert noe på en person siste 4 måneder.

Lager en egen PR på oppgave-opprettingen som sjekker at det ikke er lagd oppgave på personen fra før.

Testet OK i preprod.