### PR TITLE
Opprette oppgave når nytt vedtak er uføretrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektController.kt
@@ -21,6 +21,7 @@ class InntektController(val vedtakendringer: VedtakendringerService) {
     @GetMapping("/opprettOppgaver")
     fun opprettOppgaverForInntektsendringer(@RequestParam skalOppretteOppgaver: Boolean): ResponseEntity<Int> {
         val antallOppgaver = vedtakendringer.opprettOppgaverForInntektsendringer(skalOppretteOppgaver)
+        vedtakendringer.opprettOppgaverForNyeVedtakUføretrygd()
         return ResponseEntity.ok(antallOppgaver)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerScheduler.kt
@@ -15,5 +15,6 @@ class InntektsendringerScheduler(val vedtakendringerService: VedtakendringerServ
         logger.info("Cron scheduler starter inntektskontroll")
         vedtakendringerService.beregnInntektsendringerOgLagreIDb()
         vedtakendringerService.opprettOppgaverForInntektsendringer(true)
+        vedtakendringerService.opprettOppgaverForNyeVedtakUføretrygd()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -117,7 +117,7 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
     }
 
     fun hentInntektsendringerForUføretrygd(): List<InntektOgVedtakEndring> {
-        val sql = "select * from inntektsendringer where ny_ytelse_type like '%ufoeretrygd%'"
+        val sql = "SELECT * FROM inntektsendringer WHERE harnyttvedtak is TRUE AND ny_ytelse_type like '%ufoeretrygd%'"
         return namedParameterJdbcTemplate.query(sql, inntektsendringerMapper)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepository.kt
@@ -116,6 +116,11 @@ class EfVedtakRepository(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         return namedParameterJdbcTemplate.query(sql, inntektsendringerMapper)
     }
 
+    fun hentInntektsendringerForUføretrygd(): List<InntektOgVedtakEndring> {
+        val sql = "select * from inntektsendringer where ny_ytelse_type like '%ufoeretrygd%'"
+        return namedParameterJdbcTemplate.query(sql, inntektsendringerMapper)
+    }
+
     private val inntektsendringerMapper = { rs: ResultSet, _: Int ->
         InntektOgVedtakEndring(
             rs.getString("person_ident"),

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -115,4 +115,32 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
         hentInntektsendringer = efVedtakRepository.hentInntektsendringerSomSkalHaOppgave()
         Assertions.assertThat(hentInntektsendringer.isEmpty()).isTrue
     }
+
+    @Test
+    fun `lagre inntektsendringer og hent vedtak for uføretrygd`() {
+        val inntektsendring = Inntektsendring(
+            BeregningResultat(150, 15, 10000),
+            BeregningResultat(250, 10, 5000),
+            BeregningResultat(350, 25, 2500),
+            BeregningResultat(500, 35, 12000),
+        )
+        efVedtakRepository.lagreVedtakOgInntektsendringForPersonIdent(
+            "1",
+            true,
+            "sykepenger, ufoeretrygd",
+            inntektsendring,
+        )
+        efVedtakRepository.lagreVedtakOgInntektsendringForPersonIdent(
+            "2",
+            true,
+            "sykepenger",
+            inntektsendring,
+        )
+
+        var hentInntektsendringer = efVedtakRepository.hentInntektsendringerForUføretrygd()
+        Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)
+
+        val inntektsendringMedNyYtelseForUføretrygd = hentInntektsendringer.first()
+        Assertions.assertThat(inntektsendringMedNyYtelseForUføretrygd.nyeYtelser).contains("ufoeretrygd")
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/vedtak/EfVedtakRepositoryTest.kt
@@ -136,6 +136,12 @@ class EfVedtakRepositoryTest : IntegrasjonSpringRunnerTest() {
             "sykepenger",
             inntektsendring,
         )
+        efVedtakRepository.lagreVedtakOgInntektsendringForPersonIdent(
+            "2",
+            false,
+            "sykepenger, ufoeretrygd",
+            inntektsendring,
+        )
 
         var hentInntektsendringer = efVedtakRepository.hentInntektsendringerForUføretrygd()
         Assertions.assertThat(hentInntektsendringer.size).isEqualTo(1)


### PR DESCRIPTION
Hvorfor ? 

For å redusere potensielle feilutbetalinger skal det opprettes oppgave for inntektsendring hvis det har blitt innvilget uføretrygd, siden overgangsstønaden skal reduseres krone for krone med uføretrygd. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20312