### PR TITLE
Etterbetalinger skal ikke lenger ignoreres

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -84,8 +84,7 @@ class InntektsendringerService(
             }.flatMap { it.arbeidsInntektInformasjon.inntektListe!! }
         val samletInntekt =
             inntektListe.filterNot {
-                ignorerteYtelserOgUtbetalinger.contains(it.beskrivelse) ||
-                    (it.inntektType == InntektType.YTELSE_FRA_OFFENTLIGE && it.tilleggsinformasjon?.tilleggsinformasjonDetaljer?.detaljerType == "ETTERBETALINGSPERIODE")
+                ignorerteYtelserOgUtbetalinger.contains(it.beskrivelse)
             }.sumOf { it.beløp }
 
         if (samletInntekt < halvtGrunnbeløpMånedlig) return BeregningResultat(0, 0, 0)


### PR DESCRIPTION
I starten av 2022 var det mange som fikk etterbetalinger av sykepenger, noe som gjorde at vi bestemte vi ignorerte disse da det kunne gjelde for en periode som var veldig langt tilbake i tid, da det var stort etterslep på utbetaling av sykepenger. Det er nå bestemt av funksjonelle at etterbetalinger av ytelser ikke skal ignoreres lenger.