### PR TITLE
Oppdatert kafka config. Det er blant annet tydeligere hvilken config som gjelder for hvilket topic

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/configuration/KafkaConfig.kt
@@ -1,17 +1,20 @@
 package no.nav.familie.ef.personhendelse.configuration
 
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import no.nav.familie.kafka.KafkaErrorHandler
 import no.nav.person.pdl.leesah.Personhendelse
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.boot.ssl.SslBundles
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
-import org.springframework.kafka.listener.ContainerProperties
+import org.springframework.kafka.listener.ContainerProperties.AckMode
 
 @EnableKafka
 @Configuration
@@ -20,25 +23,15 @@ class KafkaConfig {
     fun kafkaAivenPersonhendelseListenerContainerFactory(
         properties: KafkaProperties,
         kafkaErrorHandler: KafkaErrorHandler,
+        sslBundles: ObjectProvider<SslBundles>,
     ): ConcurrentKafkaListenerContainerFactory<Long, Personhendelse> {
-        properties.properties[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = "true"
         val factory = ConcurrentKafkaListenerContainerFactory<Long, Personhendelse>()
-        factory.consumerFactory = DefaultKafkaConsumerFactory(properties.buildConsumerProperties())
-        factory.setCommonErrorHandler(kafkaErrorHandler)
-        return factory
-    }
+        factory.containerProperties.ackMode = AckMode.MANUAL_IMMEDIATE
 
-    @Bean
-    fun kafkaVedtakListenerContainerFactory(
-        properties: KafkaProperties,
-        kafkaErrorHandler: KafkaErrorHandler,
-    ): ConcurrentKafkaListenerContainerFactory<String, String> {
-        val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
-        factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
-        val props = properties.buildConsumerProperties()
-        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        props[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = false
+        val props = fellesProperties(properties.buildConsumerProperties(sslBundles.getIfAvailable()))
+        props[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = true
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAvroDeserializer::class.java
+
         factory.consumerFactory = DefaultKafkaConsumerFactory(props)
         factory.setCommonErrorHandler(kafkaErrorHandler)
         return factory
@@ -48,15 +41,25 @@ class KafkaConfig {
     fun kafkaKontantstøtteVedtakListenerContainerFactory(
         properties: KafkaProperties,
         kafkaErrorHandler: KafkaErrorHandler,
+        sslBundles: ObjectProvider<SslBundles>,
     ): ConcurrentKafkaListenerContainerFactory<String, String> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
-        factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
-        val props = properties.buildConsumerProperties()
-        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        factory.containerProperties.ackMode = AckMode.MANUAL_IMMEDIATE
+
+        val props = fellesProperties(properties.buildConsumerProperties(sslBundles.getIfAvailable()))
         props[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = false
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+
         factory.consumerFactory = DefaultKafkaConsumerFactory(props)
         factory.setCommonErrorHandler(kafkaErrorHandler)
         return factory
+    }
+
+    private fun fellesProperties(consumerProperties: MutableMap<String, Any>): MutableMap<String, Any> {
+        consumerProperties[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        consumerProperties[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = 1
+        consumerProperties[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        consumerProperties[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
+        return consumerProperties
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListener.kt
@@ -10,6 +10,7 @@ import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.listener.ConsumerSeekAware
+import org.springframework.kafka.support.Acknowledgment
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -34,6 +35,7 @@ class PersonhendelseListener(
     )
     fun listen(
         @Payload personhendelse: Personhendelse,
+        ack: Acknowledgment,
     ) {
         try {
             MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
@@ -52,6 +54,7 @@ class PersonhendelseListener(
             } else {
                 if (env != "dev") throw RuntimeException("Hendelse uten personIdent mottatt for hendelseId: ${personhendelse.hendelseId}")
             }
+            ack.acknowledge()
         } catch (e: Exception) {
             logger.error("Feil ved håndtering av personhendelse med hendelseId: ${personhendelse.hendelseId}")
             securelogger.error(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,12 +45,6 @@ spring:
           type: PKCS12
           location: ${KAFKA_TRUSTSTORE_PATH}
           password: ${KAFKA_CREDSTORE_PASSWORD}
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-      max-poll-records: 1
-      auto-offset-reset: latest
-      enable-auto-commit: false
 
 no.nav.security.jwt:
   issuer:

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListenerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/kafka/PersonhendelseListenerTest.kt
@@ -11,12 +11,13 @@ import no.nav.person.pdl.leesah.Personhendelse
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.kafka.support.Acknowledgment
 import java.util.UUID
 
 internal class PersonhendelseListenerTest {
     private val sakClient = mockk<SakClient>()
     private val personhendelseService = mockk<PersonhendelseService>(relaxed = true)
-
+    private val ack = mockk<Acknowledgment>(relaxed = true)
     private lateinit var listener: PersonhendelseListener
 
     private val personMedSak = "11111111111"
@@ -31,7 +32,7 @@ internal class PersonhendelseListenerTest {
 
     @Test
     internal fun `skal kalle på personhendelseService for hendelse`() {
-        listener.listen(lagPersonhendelse(personIdent = personUtenSak))
+        listener.listen(lagPersonhendelse(personIdent = personUtenSak), ack)
 
         verify(exactly = 1) { personhendelseService.håndterPersonhendelse(any()) }
     }
@@ -39,7 +40,7 @@ internal class PersonhendelseListenerTest {
     @Test
     internal fun `skal kaste feil når hendelse mangler personidenter`() {
         val personhendelse = lagPersonhendelse(personIdent = "")
-        assertThatThrownBy { listener.listen(personhendelse) }.hasMessageContaining("Hendelse uten personIdent")
+        assertThatThrownBy { listener.listen(personhendelse, ack) }.hasMessageContaining("Hendelse uten personIdent")
 
         verify(exactly = 0) { personhendelseService.håndterPersonhendelse(any()) }
     }

--- a/src/test/resources/application-integrasjonstest.yml
+++ b/src/test/resources/application-integrasjonstest.yml
@@ -9,13 +9,7 @@ spring:
       schema.registry.url: http://localhost:8081
       security:
         protocol: PLAINTEXT
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-      group-id: srvc01
-      max-poll-records: 1
-      auto-offset-reset: latest
-      enable-auto-commit: false
+
 
 AZURE_APP_WELL_KNOWN_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth/v2.0/token

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -15,13 +15,6 @@ spring:
       sasl:
         mechanism: PLAIN
         jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="username" password="password";
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-      group-id: srvfamilie-ef-person
-      max-poll-records: 1
-      auto-offset-reset: latest
-      enable-auto-commit: false
 
 
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.dev-fss-pub.nais.io


### PR DESCRIPTION
### Gjennomgang av kafka config
Setter `auto-offset-reset: earliest` for å sikre at ingen hendelser går tapt dersom offset mangler eller blir slettet. Ulempen er at dersom det må leses fra start, kan det ta noe tid (leesah/personhendelse-topic har 30 dagers retention). Likevel anses det som akseptabelt at hendelser i verste fall leses en dag etter publisering. For kontantstøtte-vedtak-topicet, som har 60 dagers retention og relativt få hendelser, er det også uproblematisk å lese fra start om offset mistes.

**Transaksjoner**
Konfigurasjon av transaksjoner og offset-commit kan være litt forvirrende siden det finnes to forskjellige innstillinger: `enable-auto-commit: true/false` og `ackMode`. `enable-auto-commit` er en Kafka-native innstilling, mens `ackMode` er spesifikk for Spring, og de fungerer i utgangspunktet uavhengig av hverandre. Problemer kan imidlertid oppstå hvis de er konfigurert på en «motstridende» måte. Generelt anbefales det å sette enable-auto-commit til false og la `ackMode` styre offset-commit. Det er sjelden nødvendig å sette auto-commit til true i applikasjoner. I enkelte tilfeller, som PoC eller logging hvor duplikater ikke er kritiske, kan auto-commit være hensiktsmessig. For de fleste produksjonsapplikasjoner er det imidlertid tryggest å sette auto-commit til false og konfigurere offset-commit med ackMode i Spring.

Standard `ackMode` i Spring er `BATCH`, som betyr at Spring committer offset etter at en batch er fullstendig prosessert. Siden vi ønsker å prioritere stabilitet og robusthet fremfor ytelse i alle apper, er det fornuftig å sette `ackMode` til `MANUAL_IMMEDIATE`. Dette gjør at offset committer så snart `ack.acknowledge()` kalles, uten å vente på eventuell post-prosessering som Spring ellers ville ha utført før commit.

`max-poll-records` er fortsatt viktig å sette, siden den styrer hvor mange hendelser som hentes inn til prosessering per poll, uavhengig av transaksjoner. Generelt anbefales det å ha en lav verdi dersom stabilitet prioriteres over ytelse. Jeg har satt denne til 1 for å være på den sikre siden, da ytelse ikke er et problem i vårt tilfelle, men det kan være noe defensivt.

**Tiltak for å gjøre konfigurasjon mer forståelig**
For apper med flere Kafka-listenere kan det være hensiktsmessig å unngå Kafka-consumer-konfigurasjon i `application.yaml`, da det lett kan bli uklart hvilke listenere konfigurasjonen gjelder for. I stedet anbefales det å opprette en egen `kafkaListenerContainerFactory` per topic, ettersom ulike topics ofte har behov for spesifikk konfigurasjon – for eksempel om de bruker Avro eller ikke. 

Dette er hva jeg har kommet frem til, men er selvfølgelig åpen for diskusjon :) 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15829)
