### PR TITLE
Delautomatisering av inntektsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
@@ -96,6 +96,15 @@ class SakClient(
         val response = postForEntity<Ressurs<NyeBarnDto>>(uriComponentsBuilder.build().toUri(), personIdent)
         return response.getDataOrThrow()
     }
+
+    fun automatiskRevurdering(personIdenter: List<String>): List<AutomatiskRevurdering>? {
+        val uriComponentsBuilder =
+            UriComponentsBuilder
+                .fromUri(uri)
+                .pathSegment("api/revurdering/automatisk")
+        val response = postForEntity<Ressurs<List<AutomatiskRevurdering>>>(uriComponentsBuilder.build().toUri(), personIdenter)
+        return response.data
+    }
 }
 
 data class ForventetInntektForPerson(
@@ -104,4 +113,9 @@ data class ForventetInntektForPerson(
     val forventetInntektToMånederTilbake: Int?,
     val forventetInntektTreMånederTilbake: Int?,
     val forventetInntektFireMånederTilbake: Int?,
+)
+
+data class AutomatiskRevurdering(
+    val personIdent: String,
+    val automatiskRevurdert: Boolean,
 )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/client/SakClient.kt
@@ -97,11 +97,11 @@ class SakClient(
         return response.getDataOrThrow()
     }
 
-    fun automatiskRevurdering(personIdenter: List<String>): List<AutomatiskRevurdering>? {
+    fun revurderAutomatisk(personIdenter: List<String>): List<AutomatiskRevurdering>? {
         val uriComponentsBuilder =
             UriComponentsBuilder
                 .fromUri(uri)
-                .pathSegment("api/revurdering/automatisk")
+                .pathSegment("api/automatisk-revurdering")
         val response = postForEntity<Ressurs<List<AutomatiskRevurdering>>>(uriComponentsBuilder.build().toUri(), personIdenter)
         return response.data
     }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektController.kt
@@ -19,6 +19,12 @@ class InntektController(
         return ResponseEntity.ok().build()
     }
 
+    @GetMapping("/automatisk-revurdering-dryrun")
+    fun loggAutomatiskInntektsendring(): ResponseEntity<Any> {
+        inntektsendringerService.loggAutomatiskRevurder()
+        return ResponseEntity.ok().build()
+    }
+
     @GetMapping("/opprettOppgaver")
     fun opprettOppgaverForInntektsendringer(
         @RequestParam skalOppretteOppgaver: Boolean,

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektController.kt
@@ -20,8 +20,8 @@ class InntektController(
     }
 
     @GetMapping("/automatisk-revurdering-dryrun")
-    fun loggAutomatiskInntektsendring(): ResponseEntity<Any> {
-        inntektsendringerService.loggAutomatiskRevurder()
+    fun loggAutomatiskeInntektsendringer(): ResponseEntity<Any> {
+        inntektsendringerService.loggAutomatiskeRevurderinger()
         return ResponseEntity.ok().build()
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.personhendelse.client.ForventetInntektForPerson
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.client.fristFerdigstillelse
-import no.nav.familie.ef.personhendelse.client.pdl.secureLogger
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
@@ -38,10 +37,10 @@ class InntektsendringerService(
         beregnInntektsendringerOgLagreIDb()
     }
 
-    fun loggAutomatiskRevurder() {
+    fun loggAutomatiskeRevurderinger() {
         val inntektsendringer = inntektsendringerRepository.hentBrukereMedInntektsendringOver10Prosent()
         val automatiskRevurderingKandidater = inntektsendringer.filter { !it.harNyeVedtak && it.harStabilInntekt() }
-        sakClient.automatiskRevurdering(automatiskRevurderingKandidater.map { it.personIdent })
+        sakClient.revurderAutomatisk(automatiskRevurderingKandidater.map { it.personIdent })
     }
 
     fun beregnInntektsendringerOgLagreIDb() {

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -38,6 +38,12 @@ class InntektsendringerService(
         beregnInntektsendringerOgLagreIDb()
     }
 
+    fun loggAutomatiskRevurder() {
+        val inntektsendringer = inntektsendringerRepository.hentBrukereMedInntektsendringOver10Prosent()
+        val automatiskRevurderingKandidater = inntektsendringer.filter { !it.harNyeVedtak && it.harStabilInntekt() }
+        sakClient.automatiskRevurdering(automatiskRevurderingKandidater.map { it.personIdent })
+    }
+
     fun beregnInntektsendringerOgLagreIDb() {
         logger.info("Starter beregning av inntektsendringer")
         val personerMedAktivStønad = sakClient.hentPersonerMedAktivStønadIkkeManueltRevurdertSisteMåneder(3)
@@ -74,6 +80,7 @@ class InntektsendringerService(
             nyeVedtak?.isNotEmpty() ?: false,
             nyeVedtak?.joinToString(),
             endretInntekt,
+            VedtakendringerUtil.offentligeYtelserForNyesteMåned(response)?.joinToString(),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringerUtil.kt
@@ -5,6 +5,12 @@ import java.time.YearMonth
 object VedtakendringerUtil {
     fun harNyeVedtak(response: HentInntektListeResponse) = nyeVedtak(response)?.isNotEmpty() ?: false
 
+    fun offentligeYtelserForNyesteMåned(inntektResponse: HentInntektListeResponse): List<String>? {
+        val nyesteRegistrerteInntekt =
+            inntektResponse.arbeidsinntektMåned?.filter { it.årMåned == YearMonth.now().minusMonths(1) }
+        return offentligeYtelser(nyesteRegistrerteInntekt)
+    }
+
     fun nyeVedtak(inntektResponse: HentInntektListeResponse): List<String>? {
         // hent alle registrerte vedtak som var på personen sist beregning
         val nyesteRegistrerteInntekt =

--- a/src/main/resources/db/migration/V15__lagre_naavaerende_vedtak.sql
+++ b/src/main/resources/db/migration/V15__lagre_naavaerende_vedtak.sql
@@ -1,0 +1,1 @@
+ALTER TABLE inntektsendringer ADD COLUMN eksisterende_ytelser VARCHAR;

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerRepositoryTest.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ef.personhendelse.inntekt
+
+import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class InntektsendringerRepositoryTest : IntegrasjonSpringRunnerTest() {
+    @Autowired
+    lateinit var inntektsendringerRepository: InntektsendringerRepository
+
+    @Test
+    fun `lagre og hent ut inntektsendringer`() {
+        val beregningResultatList =
+            listOf(
+                BeregningResultat(1, 2, 3),
+                BeregningResultat(4, 5, 6),
+                BeregningResultat(7, 8, 9),
+                BeregningResultat(10, 11, 12),
+            )
+        inntektsendringerRepository.lagreVedtakOgInntektsendringForPersonIdent(
+            personIdent = "01010199999",
+            harNyeVedtak = true,
+            nyeYtelser = "ufoeretrygd",
+            inntektsendring =
+                Inntektsendring(
+                    fireMånederTilbake = beregningResultatList[0],
+                    treMånederTilbake = beregningResultatList[1],
+                    toMånederTilbake = beregningResultatList[2],
+                    forrigeMåned = beregningResultatList[3],
+                ),
+            eksisterendeYtelser = "sykepenger",
+        )
+
+        val inntektsendringer = inntektsendringerRepository.hentInntektsendringerForUføretrygd()
+        Assertions.assertThat(inntektsendringer.size).isEqualTo(1)
+        Assertions.assertThat(inntektsendringer.first().personIdent).isEqualTo("01010199999")
+        Assertions.assertThat(inntektsendringer.first().harNyeVedtak).isEqualTo(true)
+        Assertions.assertThat(inntektsendringer.first().nyeYtelser).isEqualTo("ufoeretrygd")
+        Assertions.assertThat(inntektsendringer.first().inntektsendringFireMånederTilbake).isEqualTo(beregningResultatList[0])
+        Assertions.assertThat(inntektsendringer.first().inntektsendringTreMånederTilbake).isEqualTo(beregningResultatList[1])
+        Assertions.assertThat(inntektsendringer.first().inntektsendringToMånederTilbake).isEqualTo(beregningResultatList[2])
+        Assertions.assertThat(inntektsendringer.first().inntektsendringForrigeMåned).isEqualTo(beregningResultatList[3])
+        Assertions.assertThat(inntektsendringer.first().eksisterendeYtelser).isEqualTo("sykepenger")
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -271,6 +271,7 @@ class InntektsendringerServiceTest {
                     BeregningResultat(3, 3, 3),
                     BeregningResultat(4, 4, 40000),
                     null,
+                    null,
                 ),
             )
 


### PR DESCRIPTION
Mulighet for å trigge automatisk revurdering fra både kall og scheduler. Inntil videre skal ikke den gjøre noe annet enn å logge, som del av analyse-arbeid. Dette er første steg for å se hvor mange som eventuelt ville ha vært kandidater til automatisk revurdering:

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23903)

Mange av kriteriene og informasjonen som trengs for å avgjøre om en bruker skal automatisk revurderes finnes i ef-sak, og det gjøres derfor et kall til ef-sak som skal ta seg evalueringen av dette. Tilhørende [PR i ef-sak](https://github.com/navikt/familie-ef-sak/pull/2776).