### PR TITLE
Barnepensjon skal ikke regnes som pensjonsgivende inntekt og skal ikke slås ut i inntektskontroll

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -262,6 +262,7 @@ class InntektsendringerService(
             "ufoeretrygd",
             "ufoereytelseEtteroppgjoer",
             "ufoerepensjonFraAndreEnnFolketrygden",
+            "barnepensjon",
         )
 }
 


### PR DESCRIPTION
Funnet ut sammen med Mirja etter gjennomgang av inntektskontroll.