### PR TITLE
Trigger automatisk revurdering på nytt, uten og hente inntekt å beregne alt på nytt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerScheduler.kt
@@ -20,4 +20,10 @@ class InntektsendringerScheduler(
         inntektsendringerService.opprettOppgaverForNyeVedtakUføretrygd()
         inntektsendringerService.hentPersonerMedInntektsendringerOgRevurderAutomatisk()
     }
+
+    @Scheduled(cron = "\${INNTEKTSKONTROLL_CRON_EXPRESSION}") // kl 04:00 den 6. hver måned
+    fun hentPersonerMedInntektsendringerOgRevurderAutomatisk() {
+        logger.info("Cron scheduler starter hentPersonerMedInntektsendringerOgRevurderAutomatisk")
+        inntektsendringerService.hentPersonerMedInntektsendringerOgRevurderAutomatisk()
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,4 @@ rolle:
   forvalter: "59865891-62a0-4fe3-b282-2e38210d1fbb" # teamfamilie-ef-forvaltning
 
 INNTEKTSKONTROLL_CRON_EXPRESSION: 0 0 10 3 * * # kl 10:00 den 3. hver måned
+AUTOMATISK_REVURDERING_CRON_EXPRESSION: 0 0 13 3 * * # kl 04:00 den 6. hver måned

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,6 +148,7 @@ INNTEKT_URL: https://ikomp.prod-fss-pub.nais.io
 INNTEKT_SCOPE: api://prod-fss.team-inntekt.ikomp/.default
 
 INNTEKTSKONTROLL_CRON_EXPRESSION: 0 0 4 6 * * # kl 04:00 den 6. hver måned
+AUTOMATISK_REVURDERING_CRON_EXPRESSION: 0 0 13 6 * * # kl 04:00 den 6. hver måned
 OPPGAVERDØDSFALL_CRON_EXPRESSION: 0 0 5 * * * # kl 05:00 hver dag
 
 AZURE_APP_TENANT_ID: navq.onmicrosoft.com


### PR DESCRIPTION
Denne delen skal bare gå gjennom kandidater til revurdering og sende over til ef-sak for å opprette tasker på de som er egnet til revurdering