### PR TITLE
Fix deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     </repositories>
     <properties>
         <revision>1.0</revision>
+        <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <java.version>21</java.version>
         <kotlin.version>2.1.21</kotlin.version>


### PR DESCRIPTION
Nyeste versjon av deploy-steget har antakelig strengere validering. Version i imagenavnet går ikke gjennom validering i deploy fordi navnet ikke er statisk. Fikser dette.