### PR TITLE
Beregn stabil inntekt uten feriepenger.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/datoutil/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/datoutil/DatoUtil.kt
@@ -1,8 +1,11 @@
 package no.nav.familie.ef.personhendelse.datoutil
 
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 
 private val DATO_FORMAT_NORSK = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 
 fun LocalDate?.tilNorskDatoformat(): String = this?.format(DATO_FORMAT_NORSK) ?: "ukjent dato"
+
+fun YearMonth.isEqualOrAfter(other: YearMonth?) = other == null || this == other || this.isAfter(other)


### PR DESCRIPTION
Beregner stabil inntekt uten feriepenger. Alt som er lagret i db fra før er lagret med alle type inntekter, inkludert feriepenger. 

Det må dessverre gjøres nytt kall til a-inntekt for å sjekke hva som er feriepenger, slik at man kan se om inntekt er stabil uten feriepenger. Normalt er feriepenger registrert sammen med fastlønn. En typisk feriemåned har fastlønn, feriepenger og trekk for feriepenger. Hvis feriepenger og trekk for feriepenger ikke tas med i beregningen, så står man bare igjen med fastlønn, som er det vi er ute etter. Det er typisk ikke så mange kandidater til automatisk revurdering av inntekt, så det er helt greit at det gjøres nytt kall mot a-inntekt for disse.