### PR TITLE
Ignorerer introduksjonsstoenad som inntekt, da dette ikke skal gå utover uredusert stønad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerService.kt
@@ -277,6 +277,7 @@ class InntektsendringerService(
             "ufoereytelseEtteroppgjoer",
             "ufoerepensjonFraAndreEnnFolketrygden",
             "barnepensjon",
+            "introduksjonsstoenad",
         )
 }
 


### PR DESCRIPTION
Det må avklares om dette er godt nok når funksjonelle er tilbake fra ferie. Det kan hende at introduksjonsstønaden må medberegnes hvis det finnes tilfeller av brukere med inntekt ved siden av introduksjonsstønaden.