### PR TITLE
Logg inntekt for person

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/forvaltning/BehandleAutomatiskInntektsendringForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/forvaltning/BehandleAutomatiskInntektsendringForvaltningsController.kt
@@ -75,10 +75,12 @@ class BehandleAutomatiskInntektsendringForvaltningsController(
         description =
             "Logger inntekt for person. Send med fnr i body.",
         summary =
-            "Logg inntekt for person."
+            "Logg inntekt for person.",
     )
     @PostMapping("/logg-inntekt-for-person")
-    fun loggInntektForPerson(@RequestBody personIdent: String) {
+    fun loggInntektForPerson(
+        @RequestBody personIdent: String,
+    ) {
         val loggInntektTask = LoggInntektForPersonTask.opprettTask(personIdent)
         taskService.save(loggInntektTask)
     }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/forvaltning/BehandleAutomatiskInntektsendringForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/forvaltning/BehandleAutomatiskInntektsendringForvaltningsController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.inntekt.InntektOppgaveService
 import no.nav.familie.ef.personhendelse.inntekt.InntektsendringerService
+import no.nav.familie.ef.personhendelse.inntekt.LoggInntektForPersonTask
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.GetMapping
@@ -68,6 +69,18 @@ class BehandleAutomatiskInntektsendringForvaltningsController(
     @GetMapping("/opprett-oppgaver-for-arbeidsavklaringspenger-endringer")
     fun opprettOppgaverForArbeidsavklaringspengerEndringer() {
         inntektOppgaveService.finnPersonerSomHarFyltTjueFemOgHarArbeidsavklaringspengerOgOpprettOppgaver(true)
+    }
+
+    @Operation(
+        description =
+            "Logger inntekt for person. Send med fnr i body.",
+        summary =
+            "Logg inntekt for person."
+    )
+    @PostMapping("/logg-inntekt-for-person")
+    fun loggInntektForPerson(@RequestBody personIdent: String) {
+        val loggInntektTask = LoggInntektForPersonTask.opprettTask(personIdent)
+        taskService.save(loggInntektTask)
     }
 
     @Operation(

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektOppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektOppgaveService.kt
@@ -75,6 +75,7 @@ class InntektOppgaveService(
             inntektsendringForBrukereMedUføretrygd.mapNotNull { endring ->
                 val inntekt = inntektsendringerService.hentInntekt(endring.personIdent) ?: return@mapNotNull null
 
+                // Juli
                 val uføretrygdForrige =
                     inntekt.inntektsmåneder
                         .find { it.måned == forrigeMåned }
@@ -82,7 +83,7 @@ class InntektOppgaveService(
                         ?.filter { it.beskrivelse == "ufoeretrygd" }
                         ?.sumOf { it.beløp }
                         ?: 0.0
-
+                // Juni
                 val uføretrygdToMnd =
                     inntekt.inntektsmåneder
                         .find { it.måned == toMånederTilbake }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
@@ -1,11 +1,10 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
-import no.nav.familie.ef.personhendelse.client.pdl.secureLogger
-import no.nav.familie.ef.personhendelse.handler.PersonhendelseService
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
 import java.time.YearMonth
 import java.util.Properties
 
@@ -18,15 +17,16 @@ import java.util.Properties
 class LoggInntektForPersonTask(
     private val inntektClient: InntektClient,
 ) : AsyncTaskStep {
+    private val securelogger = LoggerFactory.getLogger("secureLogger")
 
     override fun doTask(task: Task) {
         val inntekt = inntektClient.hentInntekt(personIdent = task.payload, YearMonth.now().minusMonths(12), YearMonth.now())
-        secureLogger.info("InntektResponse for person ${task.payload}")
-        secureLogger.info("${objectMapper.writeValueAsString(inntekt)}")
+        securelogger.info("InntektResponse for person ${task.payload}")
+        securelogger.info("${objectMapper.writeValueAsString(inntekt)}")
     }
 
     companion object {
-        const val TYPE = "logg-inntekt-for-person"
+        const val TYPE = "loggInntektForPerson"
 
         fun opprettTask(payload: String): Task =
             Task(
@@ -37,6 +37,5 @@ class LoggInntektForPersonTask(
                         this["personIdent"] = payload
                     },
             )
-
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
@@ -31,7 +31,7 @@ class LoggInntektForPersonTask(
         fun opprettTask(payload: String): Task =
             Task(
                 type = TYPE,
-                payload = objectMapper.writeValueAsString(payload),
+                payload = payload,
                 properties =
                     Properties().apply {
                         this["personIdent"] = payload

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
@@ -5,14 +5,16 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.util.Properties
 
+@Service
 @TaskStepBeskrivelse(
     taskStepType = LoggInntektForPersonTask.TYPE,
     maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
-    beskrivelse = "Oppretter oppgave for uføretrygsendringer på person",
+    beskrivelse = "Logger inntekt for gitt person",
 )
 class LoggInntektForPersonTask(
     private val inntektClient: InntektClient,

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/LoggInntektForPersonTask.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ef.personhendelse.inntekt
+
+import no.nav.familie.ef.personhendelse.client.pdl.secureLogger
+import no.nav.familie.ef.personhendelse.handler.PersonhendelseService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import java.time.YearMonth
+import java.util.Properties
+
+@TaskStepBeskrivelse(
+    taskStepType = LoggInntektForPersonTask.TYPE,
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
+    beskrivelse = "Oppretter oppgave for uføretrygsendringer på person",
+)
+class LoggInntektForPersonTask(
+    private val inntektClient: InntektClient,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val inntekt = inntektClient.hentInntekt(personIdent = task.payload, YearMonth.now().minusMonths(12), YearMonth.now())
+        secureLogger.info("InntektResponse for person ${task.payload}")
+        secureLogger.info("${objectMapper.writeValueAsString(inntekt)}")
+    }
+
+    companion object {
+        const val TYPE = "logg-inntekt-for-person"
+
+        fun opprettTask(payload: String): Task =
+            Task(
+                type = TYPE,
+                payload = objectMapper.writeValueAsString(payload),
+                properties =
+                    Properties().apply {
+                        this["personIdent"] = payload
+                    },
+            )
+
+    }
+}


### PR DESCRIPTION
Det er behov for å se InntektResponse for gitt person for å analysere inntektsendringer. 
Alternativet er å lagre til db, men dette ses som en bedre måte fordi logger vil slettes over tid.

Testet i dev for å dobbeltsjekke at dette printes ut til securelogger.