### PR TITLE
En bugfix som tar høyde for at det kan finnes flere innslag av samme måned i inntektsresponse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTask.kt
@@ -37,19 +37,17 @@ class FinnPersonerMedEndringUføretrygdTask(
 
                 val uføretrygdForrige =
                     inntekt.inntektsmåneder
-                        .find { it.måned == forrigeMåned }
-                        ?.inntektListe
-                        ?.filter { it.beskrivelse == "ufoeretrygd" }
-                        ?.sumOf { it.beløp }
-                        ?: 0.0
+                        .filter { it.måned == forrigeMåned }
+                        .flatMap { it.inntektListe }
+                        .filter { it.beskrivelse == "ufoeretrygd" }
+                        .sumOf { it.beløp }
 
                 val uføretrygdToMnd =
                     inntekt.inntektsmåneder
-                        .find { it.måned == toMånederTilbake }
-                        ?.inntektListe
-                        ?.filter { it.beskrivelse == "ufoeretrygd" }
-                        ?.sumOf { it.beløp }
-                        ?: 0.0
+                        .filter { it.måned == toMånederTilbake }
+                        .flatMap { it.inntektListe }
+                        .filter { it.beskrivelse == "ufoeretrygd" }
+                        .sumOf { it.beløp }
 
                 if (uføretrygdForrige > uføretrygdToMnd) endring else null
             }

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/IntegrasjonSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/IntegrasjonSpringRunnerTest.kt
@@ -40,6 +40,8 @@ abstract class IntegrasjonSpringRunnerTest {
     private fun resetDatabase() {
         namedParameterJdbcTemplate.update("TRUNCATE TABLE hendelse CASCADE", MapSqlParameterSource())
         namedParameterJdbcTemplate.update("TRUNCATE TABLE utsattoppgave CASCADE", MapSqlParameterSource())
+        namedParameterJdbcTemplate.update("TRUNCATE TABLE task_logg CASCADE", MapSqlParameterSource())
+        namedParameterJdbcTemplate.update("TRUNCATE TABLE task CASCADE", MapSqlParameterSource())
     }
 
     private fun resetWiremockServers() {

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTaskTest.kt
@@ -74,8 +74,8 @@ class FinnPersonerMedEndringUføretrygdTaskTest : IntegrasjonSpringRunnerTest() 
     }
 
     @Test
-    fun `sjekk virkelighetsnære data`() {
-        val json: String = readResource("inntekt/InntektEtterbetalingSkalIgnoreres.json") // Inntekt 35k + etterbetaling 10k
+    fun `Sjekk uføretrygd endring hvor det finnes flere innslag av inntekt på samme måned`() {
+        val json: String = readResource("inntekt/InntektUføretrygdUtenEndring.json")
         val inntektResponse = objectMapper.readValue<InntektResponse>(json)
 
         every { inntektsendringerService.hentInntekt(any()) } returns inntektResponse

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTaskTest.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.ef.personhendelse.inntekt
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
+import no.nav.familie.ef.personhendelse.util.JsonFilUtil.Companion.readResource
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
@@ -69,6 +71,38 @@ class FinnPersonerMedEndringUføretrygdTaskTest : IntegrasjonSpringRunnerTest() 
         assertThat(taskFraDBLagOppgave.metadata).isNotEmpty
         assertThat(taskFraDBLagOppgave.metadataWrapper.properties.keys.size).isEqualTo(3)
         assertThat(taskFraDBLagOppgave.metadataWrapper.properties.keys).contains("callId", "personIdent", "årMåned")
+    }
+
+    @Test
+    fun `sjekk virkelighetsnære data`() {
+        val json: String = readResource("inntekt/InntektEtterbetalingSkalIgnoreres.json") // Inntekt 35k + etterbetaling 10k
+        val inntektResponse = objectMapper.readValue<InntektResponse>(json)
+
+        every { inntektsendringerService.hentInntekt(any()) } returns inntektResponse
+
+        val inntektsendring =
+            InntektOgVedtakEndring(
+                personIdent = "12345",
+                harNyeVedtak = false,
+                prosessertTid = LocalDateTime.now(),
+                inntektsendringFireMånederTilbake = BeregningResultat(1000, 0, 0),
+                inntektsendringTreMånederTilbake = BeregningResultat(1000, 0, 0),
+                inntektsendringToMånederTilbake = BeregningResultat(1000, 0, 0),
+                inntektsendringForrigeMåned = BeregningResultat(1200, 10, 200),
+                nyeYtelser = null,
+                eksisterendeYtelser = "ufoeretrygd",
+            )
+        val payload =
+            PayloadFinnPersonerMedEndringUføretrygdTask(
+                inntektsendringForBrukereMedUføretrygd = listOf(inntektsendring),
+                årMåned = YearMonth.now(),
+            )
+        val payloadJson = objectMapper.writeValueAsString(payload)
+        val task = FinnPersonerMedEndringUføretrygdTask.opprettTask(payloadJson)
+        taskService.save(task)
+        finnPersonerMedEndringUføretrygdTask.doTask(task)
+
+        assertThat(taskService.findAll().filter { it.type == OpprettOppgaverForUføretrygdsendringerTask.TYPE }.size).isEqualTo(0)
     }
 }
 

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import no.nav.familie.ef.personhendelse.client.ForventetInntektForPerson
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.util.JsonFilUtil.Companion.readResource
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions
@@ -244,11 +245,6 @@ class InntektsendringerServiceTest {
                     ).harEndretInntekt(),
             ).isTrue
     }
-
-    fun readResource(name: String): String =
-        this::class.java.classLoader
-            .getResource(name)!!
-            .readText(StandardCharsets.UTF_8)
 
     fun inntektsendring(
         beløp: Int = 0,

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/VedtakendringUtilTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.personhendelse.util.JsonFilUtil.Companion.readResource
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -129,9 +130,4 @@ class VedtakendringUtilTest {
 
         Assertions.assertThat(VedtakendringerUtil.harNyeVedtak(oppdatertInntektResponse)).isFalse
     }
-
-    fun readResource(name: String): String =
-        this::class.java.classLoader
-            .getResource(name)!!
-            .readText(StandardCharsets.UTF_8)
 }

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/util/JsonFilUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/util/JsonFilUtil.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ef.personhendelse.util
+
+import java.nio.charset.StandardCharsets
+
+class JsonFilUtil {
+    companion object {
+        fun readResource(name: String): String =
+            this::class.java.classLoader
+                .getResource(name)!!
+                .readText(StandardCharsets.UTF_8)
+    }
+}

--- a/src/test/resources/inntekt/InntektUføretrygdUtenEndring.json
+++ b/src/test/resources/inntekt/InntektUføretrygdUtenEndring.json
@@ -1,0 +1,163 @@
+{
+  "data": [
+    {
+      "maaned": "2025-06",
+      "opplysningspliktig": "999999999",
+      "underenhet": "999999998",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-06-10T11:51:38.882Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 760.80,
+          "fordel": "kontantytelse",
+          "beskrivelse": "feriepenger",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": "2025-06-01",
+          "opptjeningsperiodeTom": "2025-06-30",
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-06",
+      "opplysningspliktig": "123456789",
+      "underenhet": "123456788",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-06-20T21:25:48.289Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 249.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": {
+            "type": "Etterbetalingsperiode"
+          },
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 4323.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 1214.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "ufoeretrygd",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": {
+            "type": "AldersUfoereEtterlatteAvtalefestetOgKrigspensjon"
+          },
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 24912.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "ufoeretrygd",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -345.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-07",
+      "opplysningspliktig": "123456789",
+      "underenhet": "123456789",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-07-21T13:22:45.804Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 3832.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 24912.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "ufoeretrygd",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -7352.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    }
+  ]
+}


### PR DESCRIPTION
Tidligere kode gjorde at den bare tok med første innslag av måned, selv om det fantes flere, og beregnet derfor uføretrygd til 0 for to måneder siden.