### PR TITLE
FLyttet tasks og service tilknyttet endring og oppgave til egen mappe

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/forvaltning/BehandleAutomatiskInntektsendringForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/forvaltning/BehandleAutomatiskInntektsendringForvaltningsController.kt
@@ -2,9 +2,9 @@ package no.nav.familie.ef.personhendelse.forvaltning
 
 import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.ef.personhendelse.client.SakClient
-import no.nav.familie.ef.personhendelse.inntekt.InntektOppgaveService
-import no.nav.familie.ef.personhendelse.inntekt.InntektsendringerService
 import no.nav.familie.ef.personhendelse.inntekt.LoggInntektForPersonTask
+import no.nav.familie.ef.personhendelse.inntekt.endring.InntektsendringerService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerRepository.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
+import no.nav.familie.ef.personhendelse.inntekt.endring.BeregningResultat
+import no.nav.familie.ef.personhendelse.inntekt.endring.Inntektsendring
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerScheduler.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
+import no.nav.familie.ef.personhendelse.inntekt.endring.InntektsendringerService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/FeilutbetalingBeregningUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/FeilutbetalingBeregningUtil.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.endring
 
 import java.math.BigDecimal
 import java.math.RoundingMode

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/Grunnbeløp.kt
@@ -1,14 +1,15 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.endring
 
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.YearMonth
 
 data class GrunnbeløpVerdier(
     val periode: Månedsperiode,
     val grunnbeløp: BigDecimal,
-    val halvtGrunnbeløp: BigDecimal = grunnbeløp.divide(BigDecimal(2), 0, java.math.RoundingMode.DOWN),
+    val halvtGrunnbeløp: BigDecimal = grunnbeløp.divide(BigDecimal(2), 0, RoundingMode.DOWN),
 )
 
 class Grunnbeløp {

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/InntektsendringerService.kt
@@ -1,8 +1,15 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.endring
 
 import no.nav.familie.ef.personhendelse.client.ForventetInntektForPerson
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.inntekt.Grunnbeløp
+import no.nav.familie.ef.personhendelse.inntekt.InntektClient
+import no.nav.familie.ef.personhendelse.inntekt.InntektResponse
+import no.nav.familie.ef.personhendelse.inntekt.InntektsendringerRepository
+import no.nav.familie.ef.personhendelse.inntekt.Inntektsmåned
+import no.nav.familie.ef.personhendelse.inntekt.VedtakendringerUtil
+import no.nav.familie.ef.personhendelse.inntekt.beregnFeilutbetalingForMåned
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.Logger
@@ -10,7 +17,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.time.YearMonth
-import kotlin.math.abs
 
 @Service
 class InntektsendringerService(

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/InntektsendringerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/InntektsendringerService.kt
@@ -3,13 +3,11 @@ package no.nav.familie.ef.personhendelse.inntekt.endring
 import no.nav.familie.ef.personhendelse.client.ForventetInntektForPerson
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
-import no.nav.familie.ef.personhendelse.inntekt.Grunnbeløp
 import no.nav.familie.ef.personhendelse.inntekt.InntektClient
 import no.nav.familie.ef.personhendelse.inntekt.InntektResponse
 import no.nav.familie.ef.personhendelse.inntekt.InntektsendringerRepository
 import no.nav.familie.ef.personhendelse.inntekt.Inntektsmåned
 import no.nav.familie.ef.personhendelse.inntekt.VedtakendringerUtil
-import no.nav.familie.ef.personhendelse.inntekt.beregnFeilutbetalingForMåned
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.Logger

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/RevurderAutomatiskPersonerMedInntektsendringerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/endring/RevurderAutomatiskPersonerMedInntektsendringerTask.kt
@@ -1,8 +1,8 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.endring
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.inntekt.InntektClient
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/FinnPersonerFyltTjueFemArbeidsavklaringspengerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/FinnPersonerFyltTjueFemArbeidsavklaringspengerTask.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.personhendelse.client.pdl.PdlClient

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/FinnPersonerMedEndringUføretrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/FinnPersonerMedEndringUføretrygdTask.kt
@@ -1,6 +1,7 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.personhendelse.inntekt.endring.InntektsendringerService
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/InntektOppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/InntektOppgaveService.kt
@@ -1,10 +1,11 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.familie.ef.personhendelse.client.ArbeidsfordelingClient
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
 import no.nav.familie.ef.personhendelse.client.fristFerdigstillelse
+import no.nav.familie.ef.personhendelse.inntekt.InntektsendringerRepository
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForArbeidsavklaringspengerEndringerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForArbeidsavklaringspengerEndringerTask.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -13,40 +13,40 @@ import java.util.Properties
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType = OpprettOppgaverForInntektsendringerTask.TYPE,
+    taskStepType = OpprettOppgaverForArbeidsavklaringspengerEndringerTask.TYPE,
     maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
     beskrivelse = "Oppretter oppgave for arbeidsavklaringspenger endringer på person",
 )
-class OpprettOppgaverForInntektsendringerTask(
+class OpprettOppgaverForArbeidsavklaringspengerEndringerTask(
     private val inntektOppgaveService: InntektOppgaveService,
 ) : AsyncTaskStep {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
     override fun doTask(task: Task) {
-        val (personIdent, totalFeilutbetaling, yearMonthProssesertTid) = objectMapper.readValue<PayloadOpprettOppgaverForInntektsendringerTask>(task.payload)
-        secureLogger.info("Oppretter oppgaver for inntektsendringer ${task.payload}")
-        inntektOppgaveService.opprettOppgaveForInntektsendring(personIdent, inntektOppgaveService.lagOppgavetekstForInntektsendring(totalFeilutbetaling, yearMonthProssesertTid))
+        val personIdent = objectMapper.readValue<PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask>(task.payload).personIdent
+        secureLogger.info("Oppretter oppgaver for arbeidsavklaringspenger endringer ${task.payload}")
+        inntektOppgaveService.opprettOppgaveForArbeidsavklaringspengerEndring(personIdent, inntektOppgaveService.lagOppgavetekstVedEndringArbeidsavklaringspenger())
     }
 
     companion object {
-        const val TYPE = "opprettOppgaverForInntektsendringerTask"
+        const val TYPE = "opprettOppgaverForArbeidsavklaringspengerEndringerTask"
 
-        fun opprettTask(payload: PayloadOpprettOppgaverForInntektsendringerTask): Task =
+        fun opprettTask(payload: PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask): Task =
             Task(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(payload),
                 properties =
                     Properties().apply {
                         this["personIdent"] = payload.personIdent
+                        this["årMåned"] = payload.årMåned.toString()
                     },
             )
     }
 }
 
-data class PayloadOpprettOppgaverForInntektsendringerTask(
+data class PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask(
     val personIdent: String,
-    val totalFeilutbetaling: Int,
-    val yearMonthProssesertTid: YearMonth,
+    val årMåned: YearMonth,
 )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForInntektsendringerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForInntektsendringerTask.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -13,40 +13,40 @@ import java.util.Properties
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType = OpprettOppgaverForArbeidsavklaringspengerEndringerTask.TYPE,
+    taskStepType = OpprettOppgaverForInntektsendringerTask.TYPE,
     maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
     beskrivelse = "Oppretter oppgave for arbeidsavklaringspenger endringer på person",
 )
-class OpprettOppgaverForArbeidsavklaringspengerEndringerTask(
+class OpprettOppgaverForInntektsendringerTask(
     private val inntektOppgaveService: InntektOppgaveService,
 ) : AsyncTaskStep {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
     override fun doTask(task: Task) {
-        val personIdent = objectMapper.readValue<PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask>(task.payload).personIdent
-        secureLogger.info("Oppretter oppgaver for arbeidsavklaringspenger endringer ${task.payload}")
-        inntektOppgaveService.opprettOppgaveForArbeidsavklaringspengerEndring(personIdent, inntektOppgaveService.lagOppgavetekstVedEndringArbeidsavklaringspenger())
+        val (personIdent, totalFeilutbetaling, yearMonthProssesertTid) = objectMapper.readValue<PayloadOpprettOppgaverForInntektsendringerTask>(task.payload)
+        secureLogger.info("Oppretter oppgaver for inntektsendringer ${task.payload}")
+        inntektOppgaveService.opprettOppgaveForInntektsendring(personIdent, inntektOppgaveService.lagOppgavetekstForInntektsendring(totalFeilutbetaling, yearMonthProssesertTid))
     }
 
     companion object {
-        const val TYPE = "opprettOppgaverForArbeidsavklaringspengerEndringerTask"
+        const val TYPE = "opprettOppgaverForInntektsendringerTask"
 
-        fun opprettTask(payload: PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask): Task =
+        fun opprettTask(payload: PayloadOpprettOppgaverForInntektsendringerTask): Task =
             Task(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(payload),
                 properties =
                     Properties().apply {
                         this["personIdent"] = payload.personIdent
-                        this["årMåned"] = payload.årMåned.toString()
                     },
             )
     }
 }
 
-data class PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask(
+data class PayloadOpprettOppgaverForInntektsendringerTask(
     val personIdent: String,
-    val årMåned: YearMonth,
+    val totalFeilutbetaling: Int,
+    val yearMonthProssesertTid: YearMonth,
 )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForNyeVedtakUføretrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForNyeVedtakUføretrygdTask.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -10,43 +10,42 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.util.Properties
+import kotlin.collections.set
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType = OpprettOppgaverForUføretrygdsendringerTask.TYPE,
+    taskStepType = OpprettOppgaverForNyeVedtakUføretrygdTask.TYPE,
     maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
-    beskrivelse = "Oppretter oppgave for uføretrygsendringer på person",
+    beskrivelse = "Oppretter oppgave for nye uføretrygd-vedtak på person",
 )
-class OpprettOppgaverForUføretrygdsendringerTask(
+class OpprettOppgaverForNyeVedtakUføretrygdTask(
     private val inntektOppgaveService: InntektOppgaveService,
 ) : AsyncTaskStep {
-    val logger: Logger = LoggerFactory.getLogger(this::class.java)
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
     override fun doTask(task: Task) {
-        val personIdent = objectMapper.readValue<PayloadOpprettOppgaverForUføretrygdsendringerTask>(task.payload).personIdent
-        secureLogger.info("Oppretter oppgaver for uføretrygdsendringer ${task.payload}")
-        inntektOppgaveService.opprettOppgaveForUføretrygdEndring(personIdent, inntektOppgaveService.lagOppgavetekstVedEndringUføretrygd(YearMonth.now().minusMonths(1)))
+        val personIdent = objectMapper.readValue<PayloadOpprettOppgaverForNyeVedtakUføretrygdTask>(task.payload).personIdent
+        secureLogger.info("Oppretter oppgaver for nye vedtak uføretrygd for person: $personIdent")
+        inntektOppgaveService.opprettOppgaveForInntektsendring(personIdent, inntektOppgaveService.lagOppgavetekstVedNyYtelseUføretrygd())
     }
 
     companion object {
-        const val TYPE = "opprettOppgaverForUføretrygdsendringerTask"
+        const val TYPE = "opprettOppgaverForNyeVedtakUføretrygdTask"
 
-        fun opprettTask(payload: PayloadOpprettOppgaverForUføretrygdsendringerTask): Task =
+        fun opprettTask(payload: PayloadOpprettOppgaverForNyeVedtakUføretrygdTask): Task =
             Task(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(payload),
                 properties =
                     Properties().apply {
                         this["personIdent"] = payload.personIdent
-                        this["årMåned"] = payload.årMåned.toString()
                     },
             )
     }
 }
 
-data class PayloadOpprettOppgaverForUføretrygdsendringerTask(
+data class PayloadOpprettOppgaverForNyeVedtakUføretrygdTask(
     val personIdent: String,
-    val årMåned: YearMonth,
+    val prosessertYearMonth: YearMonth,
 )

--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForUføretrygdsendringerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/oppgave/OpprettOppgaverForUføretrygdsendringerTask.kt
@@ -1,6 +1,5 @@
-package no.nav.familie.ef.personhendelse.inntekt
+package no.nav.familie.ef.personhendelse.inntekt.oppgave
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -11,42 +10,43 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.util.Properties
-import kotlin.collections.set
 
 @Service
 @TaskStepBeskrivelse(
-    taskStepType = OpprettOppgaverForNyeVedtakUføretrygdTask.TYPE,
+    taskStepType = OpprettOppgaverForUføretrygdsendringerTask.TYPE,
     maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
-    beskrivelse = "Oppretter oppgave for nye uføretrygd-vedtak på person",
+    beskrivelse = "Oppretter oppgave for uføretrygsendringer på person",
 )
-class OpprettOppgaverForNyeVedtakUføretrygdTask(
+class OpprettOppgaverForUføretrygdsendringerTask(
     private val inntektOppgaveService: InntektOppgaveService,
 ) : AsyncTaskStep {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
     override fun doTask(task: Task) {
-        val personIdent = objectMapper.readValue<PayloadOpprettOppgaverForNyeVedtakUføretrygdTask>(task.payload).personIdent
-        secureLogger.info("Oppretter oppgaver for nye vedtak uføretrygd for person: $personIdent")
-        inntektOppgaveService.opprettOppgaveForInntektsendring(personIdent, inntektOppgaveService.lagOppgavetekstVedNyYtelseUføretrygd())
+        val personIdent = objectMapper.readValue<PayloadOpprettOppgaverForUføretrygdsendringerTask>(task.payload).personIdent
+        secureLogger.info("Oppretter oppgaver for uføretrygdsendringer ${task.payload}")
+        inntektOppgaveService.opprettOppgaveForUføretrygdEndring(personIdent, inntektOppgaveService.lagOppgavetekstVedEndringUføretrygd(YearMonth.now().minusMonths(1)))
     }
 
     companion object {
-        const val TYPE = "opprettOppgaverForNyeVedtakUføretrygdTask"
+        const val TYPE = "opprettOppgaverForUføretrygdsendringerTask"
 
-        fun opprettTask(payload: PayloadOpprettOppgaverForNyeVedtakUføretrygdTask): Task =
+        fun opprettTask(payload: PayloadOpprettOppgaverForUføretrygdsendringerTask): Task =
             Task(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(payload),
                 properties =
                     Properties().apply {
                         this["personIdent"] = payload.personIdent
+                        this["årMåned"] = payload.årMåned.toString()
                     },
             )
     }
 }
 
-data class PayloadOpprettOppgaverForNyeVedtakUføretrygdTask(
+data class PayloadOpprettOppgaverForUføretrygdsendringerTask(
     val personIdent: String,
-    val prosessertYearMonth: YearMonth,
+    val årMåned: YearMonth,
 )

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FeilutbetalingBeregningUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FeilutbetalingBeregningUtilTest.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
+import no.nav.familie.ef.personhendelse.inntekt.endring.Grunnbeløp
+import no.nav.familie.ef.personhendelse.inntekt.endring.beregnFeilutbetalingForMåned
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerFyltTjueFemArbeidsavklaringspengerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerFyltTjueFemArbeidsavklaringspengerTaskTest.kt
@@ -6,6 +6,9 @@ import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.personhendelse.client.pdl.PdlClient
 import no.nav.familie.ef.personhendelse.generated.hentperson.Foedselsdato
 import no.nav.familie.ef.personhendelse.generated.hentperson.Person
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.FinnPersonerFyltTjueFemArbeidsavklaringspengerTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.OpprettOppgaverForArbeidsavklaringspengerEndringerTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.PayloadFinnPersonerFyltTjueFemArbeidsavklaringspengerTask
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -59,8 +62,10 @@ class FinnPersonerFyltTjueFemArbeidsavklaringspengerTaskTest : IntegrasjonSpring
         val task = FinnPersonerFyltTjueFemArbeidsavklaringspengerTask.opprettTask(payload)
         taskService.save(task)
         finnPersonerFyltTjueFemArbeidsavklaringspengerTask.doTask(task)
-        val taskListFinnPersonerTask = taskService.finnAlleTaskerMedType(FinnPersonerFyltTjueFemArbeidsavklaringspengerTask.TYPE)
-        val taskListOpprettOppgaveTask = taskService.finnAlleTaskerMedType(OpprettOppgaverForArbeidsavklaringspengerEndringerTask.TYPE)
+        val taskListFinnPersonerTask =
+            taskService.finnAlleTaskerMedType(FinnPersonerFyltTjueFemArbeidsavklaringspengerTask.TYPE)
+        val taskListOpprettOppgaveTask =
+            taskService.finnAlleTaskerMedType(OpprettOppgaverForArbeidsavklaringspengerEndringerTask.TYPE)
         assertThat(taskListFinnPersonerTask).hasSize(1)
         assertThat(taskListOpprettOppgaveTask).hasSize(1)
         val taskFraDBFinnPerson = taskListFinnPersonerTask.first()

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/FinnPersonerMedEndringUføretrygdTaskTest.kt
@@ -3,6 +3,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
+import no.nav.familie.ef.personhendelse.inntekt.endring.InntektsendringerService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.FinnPersonerMedEndringUføretrygdTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.OpprettOppgaverForUføretrygdsendringerTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.PayloadFinnPersonerMedEndringUføretrygdTask
 import no.nav.familie.ef.personhendelse.util.JsonFilUtil.Companion.readResource
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
@@ -11,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.YearMonth
 

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/GrunnbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/GrunnbeløpTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
+import no.nav.familie.ef.personhendelse.inntekt.endring.Grunnbeløp
 import org.junit.Test
 
 class GrunnbeløpTest {

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektOgVedtakEndringTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektOgVedtakEndringTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
+import no.nav.familie.ef.personhendelse.inntekt.endring.BeregningResultat
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektOppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektOppgaveServiceTest.kt
@@ -4,7 +4,7 @@ import io.mockk.mockk
 import no.nav.familie.ef.personhendelse.client.ArbeidsfordelingClient
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
-import no.nav.familie.ef.personhendelse.client.pdl.PdlClient
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerRepositoryTest.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
+import no.nav.familie.ef.personhendelse.inntekt.endring.BeregningResultat
+import no.nav.familie.ef.personhendelse.inntekt.endring.Inntektsendring
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektsendringerServiceTest.kt
@@ -6,13 +6,15 @@ import io.mockk.mockk
 import no.nav.familie.ef.personhendelse.client.ForventetInntektForPerson
 import no.nav.familie.ef.personhendelse.client.OppgaveClient
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.inntekt.endring.BeregningResultat
+import no.nav.familie.ef.personhendelse.inntekt.endring.Inntektsendring
+import no.nav.familie.ef.personhendelse.inntekt.endring.InntektsendringerService
 import no.nav.familie.ef.personhendelse.util.JsonFilUtil.Companion.readResource
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.nio.charset.StandardCharsets
 import java.time.YearMonth
 
 class InntektsendringerServiceTest {

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForArbeidsavklaringspengerEndringerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForArbeidsavklaringspengerEndringerTaskTest.kt
@@ -3,7 +3,9 @@ package no.nav.familie.ef.personhendelse.inntekt
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
-import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.OpprettOppgaverForArbeidsavklaringspengerEndringerTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.PayloadOpprettOppgaverForArbeidsavklaringspengerEndringerTask
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForInntektsendringerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForInntektsendringerTaskTest.kt
@@ -3,6 +3,9 @@ package no.nav.familie.ef.personhendelse.inntekt
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.OpprettOppgaverForInntektsendringerTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.PayloadOpprettOppgaverForInntektsendringerTask
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForNyeVedtakUføretrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForNyeVedtakUføretrygdTaskTest.kt
@@ -3,7 +3,9 @@ package no.nav.familie.ef.personhendelse.inntekt
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
-import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.OpprettOppgaverForNyeVedtakUføretrygdTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.PayloadOpprettOppgaverForNyeVedtakUføretrygdTask
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForUføretrygdsendringerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/OpprettOppgaverForUføretrygdsendringerTaskTest.kt
@@ -3,7 +3,9 @@ package no.nav.familie.ef.personhendelse.inntekt
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
-import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.InntektOppgaveService
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.OpprettOppgaverForUføretrygdsendringerTask
+import no.nav.familie.ef.personhendelse.inntekt.oppgave.PayloadOpprettOppgaverForUføretrygdsendringerTask
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/RevurderAutomatiskPersonerMedInntektsendringerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/RevurderAutomatiskPersonerMedInntektsendringerTaskTest.kt
@@ -4,7 +4,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.personhendelse.client.SakClient
-import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ef.personhendelse.inntekt.endring.PayloadRevurderAutomatiskPersonerMedInntektsendringerTask
+import no.nav.familie.ef.personhendelse.inntekt.endring.RevurderAutomatiskPersonerMedInntektsendringerTask
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach


### PR DESCRIPTION
Flyttet tasks og service tilknyttet endring og oppgave til egen mappe. Blir mer ryddig ettersom inntekt pakken begynte å bli stor.