### PR TITLE
Bruk ny db-config i dev

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -75,6 +75,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_15
+        name: familie-ef-personhendelse-replicated
         diskAutoresize: true
         tier: db-g1-small
         cascadingDelete: false

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,3 +9,18 @@ INNTEKTSKONTROLL_CRON_EXPRESSION: 0 0 11 * * * # kl 11:00 hver dag
 
 INNTEKT_URL: https://ikomp-q2.dev-fss-pub.nais.io
 INNTEKT_SCOPE: api://dev-fss.team-inntekt.ikomp-q2/.default
+
+spring:
+  datasource:
+    url: ${DB_JDBC_URL}
+    hikari:
+      maximum-pool-size: 5
+      connection-test-query: "select 1"
+      max-lifetime: 900000
+      minimum-idle: 1
+      data-source-properties:
+        ssl: true
+        sslmode: ${DB_SSLMODE}
+        sslcert: ${DB_SSLCERT}
+        sslkey: ${DB_SSLKEY_PK8}
+        sslrootcert: ${DB_SSLROOTCERT}


### PR DESCRIPTION
Testet med ny instans i preprod, og det krever ny db-config. Replikering til ny db instans er bare gjort i dev, og det er derfor bare endret config for dev.