### PR TITLE
Sender nå personIdenter som en liste som inneholder alle personIdenter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/personhendelse/inntekt/InntektResponse.kt
@@ -24,6 +24,8 @@ data class InntektResponse(
             .filter { it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere" && it.beskrivelse != "barnepensjon" && !it.beskrivelse.contains("ferie", true) }
             .sumOf { it.beløp }
             .toInt()
+
+    fun harIkkeAndreNavYtelser(fraogMedÅr: YearMonth): Boolean = inntektsmånederFraOgMedÅrMåned(fraogMedÅr).none { it.inntektListe.any { it.type == InntektType.YTELSE_FRA_OFFENTLIGE && !it.beskrivelse.equals("overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere") } }
 }
 
 data class Inntektsmåned(

--- a/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/RevurderAutomatiskPersonerMedInntektsendringerTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/personhendelse/inntekt/RevurderAutomatiskPersonerMedInntektsendringerTaskTest.kt
@@ -1,13 +1,16 @@
 package no.nav.familie.ef.personhendelse.inntekt
 
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.personhendelse.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.personhendelse.client.SakClient
+import no.nav.familie.ef.personhendelse.inntekt.InntektClientTest.Companion.lesRessurs
+import no.nav.familie.ef.personhendelse.inntekt.endring.Inntektsendring
 import no.nav.familie.ef.personhendelse.inntekt.endring.InntektsendringerService
-import no.nav.familie.ef.personhendelse.inntekt.endring.PayloadRevurderAutomatiskPersonerMedInntektsendringerTask
-import no.nav.familie.ef.personhendelse.inntekt.endring.PersonIdentMedYtelser
 import no.nav.familie.ef.personhendelse.inntekt.endring.RevurderAutomatiskPersonerMedInntektsendringerTask
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -39,20 +42,18 @@ class RevurderAutomatiskPersonerMedInntektsendringerTaskTest : IntegrasjonSpring
 
     @Test
     fun `Sjekk at man kan opprette task for uføretrygdsendringer og at den har riktig metadata`() {
-        val personIdentMedYtelser = PersonIdentMedYtelser("12345", true)
-        val payload =
-            PayloadRevurderAutomatiskPersonerMedInntektsendringerTask(
-                personIdenterMedYtelser = listOf(personIdentMedYtelser),
-                årMåned = YearMonth.of(2023, 10),
-            )
+        val payload = listOf("123")
         val task = RevurderAutomatiskPersonerMedInntektsendringerTask.opprettTask(payload)
+        val inntektV2ResponseJson: String = lesRessurs("inntekt/InntektGenerellResponse.json")
+        val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJson)
+        every { inntektClient.hentInntekt(any(), any(), any()) } returns inntektResponse
         taskService.save(task)
         val taskList = taskService.finnAlleTaskerMedType(RevurderAutomatiskPersonerMedInntektsendringerTask.TYPE)
         assertThat(taskList).hasSize(1)
         val taskFraDB = taskList.first()
         assertThat(taskFraDB.metadata).isNotEmpty
-        assertThat(taskFraDB.metadataWrapper.properties.keys.size).isEqualTo(2)
-        assertThat(taskFraDB.metadataWrapper.properties.keys).contains("årMåned", "callId")
+        assertThat(taskFraDB.metadataWrapper.properties.keys.size).isEqualTo(1)
+        assertThat(taskFraDB.metadataWrapper.properties.keys).contains("callId")
         revurderAutomatiskPersonerMedInntektsendringerTask.doTask(task)
         verify(exactly = 1) { sakClient.revurderAutomatisk(any()) }
     }


### PR DESCRIPTION
Sender nå personIdenter som en liste som inneholder alle personIdenter. Dette er nødvendig siden vi er innteresert i å kun vurdere maks 10 i en kjøring. Som det var nå ble kun en og en personIdent send og dermed fungerte ikke logikk i ef-sak for å gjøre dette. 