### PR TITLE
Enabler swagger i application.yml for å unngå warnings

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,7 +107,10 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 
 springdoc:
+  api-docs:
+    enabled: true
   swagger-ui:
+    enabled: true
     oauth:
       use-pkce-with-authorization-code-grant: true
       client-id: ${AZURE_APP_CLIENT_ID}


### PR DESCRIPTION
Swagger er enabled fra før by default, men setter det eksplisitt i application.yml for å unngå warnings.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28266)