### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -27,7 +27,7 @@ spec:
     limits:
       memory: 768Mi
     requests:
-      memory: 256Mi
+      memory: 768Mi
       cpu: 20m
   env:
     - name: SPRING_PROFILES_ACTIVE

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -27,7 +27,7 @@ spec:
     limits:
       memory: 768Mi
     requests:
-      memory: 256Mi
+      memory: 768Mi
       cpu: 50m
   env:
     - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
