### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -25,10 +25,10 @@ spec:
     max: 2
   resources:
     limits:
-      memory: 768Mi
+      memory: 640Mi
     requests:
-      memory: 768Mi
-      cpu: 20m
+      memory: 640Mi
+      cpu: 350m
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -25,10 +25,10 @@ spec:
     max: 2
   resources:
     limits:
-      memory: 768Mi
+      memory: 704Mi
     requests:
-      memory: 768Mi
-      cpu: 50m
+      memory: 704Mi
+      cpu: 350m
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.